### PR TITLE
[TECH-434] Fix adding whitelists when none is defined for target

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -135,8 +135,9 @@ class Pipeline(ParamType):
     help='A series of arguments to pass to the pipeline. Note that will run within the pipenv in jenkins. '
          'To execute `mpyl build status`, pass `-a run -a mpyl -a build -a status`',
 )
+@click.option('--follow', '-f', is_flag=True, default=False)
 @click.pass_context
-def jenkins(ctx, user, password, pipeline, test, arguments):
+def jenkins(ctx, user, password, pipeline, test, arguments, follow):
     asyncio.run(warn_if_update(ctx.obj.console))
     selected_pipeline = pipeline if pipeline else ctx.obj.config['jenkins']['defaultPipeline']
     pipeline_parameters = {'TEST': 'true', 'VERSION': test} if test else {}
@@ -144,7 +145,8 @@ def jenkins(ctx, user, password, pipeline, test, arguments):
         pipeline_parameters['PIPENV_PARAMS'] = " ".join(arguments)
     run_argument = JenkinsRunParameters(jenkins_user=user, jenkins_password=password, config=ctx.obj.config,
                                         pipeline=selected_pipeline, pipeline_parameters=pipeline_parameters,
-                                        verbose=ctx.obj.verbose)
+                                        verbose=ctx.obj.verbose,
+                                        follow=follow)
     run_jenkins(run_argument)
 
 

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -23,6 +23,7 @@ class JenkinsRunParameters:
     pipeline: str
     pipeline_parameters: dict
     verbose: bool
+    follow: bool
 
 
 def get_token(github_config: GithubConfig):
@@ -57,8 +58,11 @@ def run_jenkins(run_config: JenkinsRunParameters):
                 status.update(f'Fetching Jenkins info for {pipeline_info.human_readable()} ...')
 
                 runner = JenkinsRunner(pipeline=pipeline_info,
-                                       jenkins=Jenkins(jenkins_config.url, username=run_config.jenkins_user,
-                                                       password=run_config.jenkins_password), status=status)
+                                       jenkins=Jenkins(baseurl=jenkins_config.url,
+                                                       username=run_config.jenkins_user,
+                                                       password=run_config.jenkins_password),
+                                       status=status,
+                                       follow=run_config.follow)
                 runner.run(run_config.pipeline_parameters)
             except requests.ConnectionError:
                 status.console.bell()

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -237,7 +237,7 @@ class ChartBuilder:
 
         def to_white_list(configured: Optional[TargetProperty[list[str]]]) -> dict[str, list[str]]:
             white_lists = self.config_defaults.white_lists['default'].copy()
-            if configured:
+            if configured and configured.get_value(self.target):
                 white_lists.extend(configured.get_value(self.target))
 
             return dict(filter(lambda x: x[0] in white_lists, address_dictionary.items()))

--- a/src/mpyl/utilities/jenkins/runner.py
+++ b/src/mpyl/utilities/jenkins/runner.py
@@ -55,6 +55,7 @@ class JenkinsRunner:
     pipeline: Pipeline
     jenkins: Jenkins
     status: Status
+    follow: bool
 
     def get_job(self, name: str) -> Job:
         try:
@@ -159,4 +160,5 @@ class JenkinsRunner:
 
         new_build_number = last_build_number + 1
 
-        self.follow_logs(job, new_build_number, last_build)
+        if self.follow:
+            self.follow_logs(job, new_build_number, last_build)

--- a/src/mpyl/utilities/jenkins/runner.py
+++ b/src/mpyl/utilities/jenkins/runner.py
@@ -109,6 +109,8 @@ class JenkinsRunner:
                 stop_build = Confirm.ask("Stop build?")
                 if stop_build:
                     build_to_follow.stop()
+                else:
+                    sys.exit()
 
             signal.signal(signal.SIGINT, cancel_handler)
             for line in build_to_follow.stream_utf_8_logs():

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -98,6 +98,13 @@ class TestKubernetesChart:
             to_yaml(route)
         assert "Schema validation failed with 1234 is not of type 'string'" in str(exc_info.value)
 
+    def test_should_not_extend_whitelists_if_none_defined_for_target(self):
+        project = test_data.get_project()
+        builder = self._get_builder(project)
+        wrappers = builder.create_host_wrappers()
+        assert test_data.RUN_PROPERTIES.target == Target.PULL_REQUEST
+        assert "Test" not in wrappers[0].white_lists
+
     @pytest.mark.parametrize('template',
                              ['deployment', 'service', 'service-account', 'sealed-secrets', 'ingress-https-route',
                               'dockertest-ingress-0-whitelist', 'dockertest-ingress-1-whitelist'])

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -68,6 +68,9 @@ deployment:
         tls:
           all: "le-custom-prod-wildcard-cert"
         insecure: true
+        whitelists:
+          test:
+            - "Test"
       - host:
           all: "Host(`some.other.host.com`)"
         servicePort: 4091


### PR DESCRIPTION
There’s a whitelist target defined for TEST, but we’re deploying a PR therefore the configured whitelists `configured.get_value(self.target)` is None, which then throws an exception when the list is extended

Example run: https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline/view/change-requests/job/PR-10515/3/console

project.yml that triggered this: https://github.com/Vandebron/Vandebron/blob/c29489fd64c9a0e97345b4ce8c6183381c1ca784/energy-trading/curtailment/curtailment-volumes-api/deployment/project.yml#L90C1-L92