### PR TITLE
append info to github pr body

### DIFF
--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -40,14 +40,14 @@ def main(log: Logger, args: argparse.Namespace):
         from mpyl.reporting.targets.github import CommitCheck
         from mpyl.reporting.targets.slack import SlackReporter
         from mpyl.steps.run import RunResult
-        from mpyl.reporting.targets.github import PullRequestComment
+        from mpyl.reporting.targets.github import PullRequestBody
         from mpyl.reporting.targets.jira import compose_build_status
         from mpyl.reporting.targets import ReportAccumulator
 
         check = CommitCheck(config=config, logger=log)
         accumulator = ReportAccumulator()
 
-        github_comment = PullRequestComment(config=config, compose_function=compose_build_status)
+        github_comment = PullRequestBody(config=config, compose_function=compose_build_status)
         slack_channel = SlackReporter(
             config,
             '#project-mpyl-notifications',

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -40,14 +40,17 @@ def main(log: Logger, args: argparse.Namespace):
         from mpyl.reporting.targets.github import CommitCheck
         from mpyl.reporting.targets.slack import SlackReporter
         from mpyl.steps.run import RunResult
-        from mpyl.reporting.targets.github import PullRequestBody
+        from mpyl.reporting.targets.github import PullRequestReporter
         from mpyl.reporting.targets.jira import compose_build_status
         from mpyl.reporting.targets import ReportAccumulator
 
         check = CommitCheck(config=config, logger=log)
         accumulator = ReportAccumulator()
 
-        github_comment = PullRequestBody(config=config, compose_function=compose_build_status)
+        github_comment = PullRequestReporter(
+            config=config,
+            compose_function=compose_build_status,
+        )
         slack_channel = SlackReporter(
             config,
             '#project-mpyl-notifications',

--- a/run_properties.yml
+++ b/run_properties.yml
@@ -8,7 +8,7 @@ build:
     user_email: !ENV ${BUILD_USER_EMAIL}
   local: !ENV ${LOCAL:true}
   parameters:
-    deploy_target: !ENV ${deployTarget:PullRequest}
+    deploy_target: !ENV ${DEPLOY_TARGET:PullRequest}
   versioning:
     revision: !ENV ${GIT_COMMIT}
     branch: !ENV ${CHANGE_BRANCH}

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -2,8 +2,8 @@
 # Github reporter
 
 ## PR comment
-Pipeline results can be reported in the form of a user comment on the pull request, using the `PullRequestComment`
- reporter.
+Pipeline results can be reported in the form of an update to the PR body or user comment on the pull request,
+using the `PullRequestReporter` class. The mode of update is determined by the `update_stategy` parameter in the constructor.
 You are recommended to use a bot account as the authenticated user.
 
 ### Installation instructions
@@ -76,6 +76,8 @@ class PullRequestReporter(Reporter):
         self.compose_function = compose_function
         self.update_strategy: GithubUpdateStategy = update_stategy
 
+        self.BODY_SEPARATOR = "----"
+
     def _get_pull_request(self, repo: GithubRepository, run_properties: RunProperties) -> Optional[PullRequest]:
         if run_properties.versioning.pr_number:
             return repo.get_pull(run_properties.versioning.pr_number)
@@ -91,7 +93,8 @@ class PullRequestReporter(Reporter):
         return self._change_pr_body
 
     def _change_pr_body(self, pull_request: PullRequest, results: RunResult):
-        current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "\n----\n"
+        current_body = (pull_request.body.split(self.BODY_SEPARATOR)[0] if pull_request.body else "") + \
+                       f"\n{self.BODY_SEPARATOR}\n"
         pull_request.edit(body=current_body + self.compose_function(results, self._raw_config))
 
     def _change_pr_comment(self, pull_request: PullRequest, results: RunResult):

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -91,7 +91,7 @@ class PullRequestReporter(Reporter):
         return self._change_pr_body
 
     def _change_pr_body(self, pull_request: PullRequest, results: RunResult):
-        current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "----"
+        current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "----\n"
         pull_request.edit(body=current_body + self.compose_function(results, self._raw_config))
 
     def _change_pr_comment(self, pull_request: PullRequest, results: RunResult):

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -61,7 +61,7 @@ class GithubOutcome(ReportOutcome):
 
 
 class GithubUpdateStategy(Enum):
-    BODY = 'body',
+    BODY = 'body'
     COMMENT = 'comment'
 
 
@@ -69,12 +69,13 @@ class PullRequestReporter(Reporter):
     _config: GithubConfig
 
     def __init__(self, config: Dict,
-                 compose_function: Callable[[RunResult, Optional[Dict]], str] = compose_message_body):
+                 compose_function: Callable[[RunResult, Optional[Dict]], str] = compose_message_body,
+                 update_stategy: GithubUpdateStategy = GithubUpdateStategy.BODY):
         self._raw_config = config
         self._config = GithubConfig.from_config(config)
         self.git_repository = Repository(RepoConfig.from_config(config))
         self.compose_function = compose_function
-        self.update_strategy: GithubUpdateStategy = GithubUpdateStategy.BODY
+        self.update_strategy: GithubUpdateStategy = update_stategy
 
     def _get_pull_request(self, repo: GithubRepository, run_properties: RunProperties) -> Optional[PullRequest]:
         if run_properties.versioning.pr_number:

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -91,7 +91,7 @@ class PullRequestReporter(Reporter):
         return self._change_pr_body
 
     def _change_pr_body(self, pull_request: PullRequest, results: RunResult):
-        current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "----\n"
+        current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "\n----\n"
         pull_request.edit(body=current_body + self.compose_function(results, self._raw_config))
 
     def _change_pr_comment(self, pull_request: PullRequest, results: RunResult):

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -31,7 +31,6 @@ Checks can be referred to from branch protection rules, in order to prevent faul
 
 """
 import base64
-import typing
 from datetime import datetime
 from enum import Enum
 from logging import Logger
@@ -89,8 +88,7 @@ class PullRequestReporter(Reporter):
     def _update_pr(self) -> Callable[[PullRequest, RunResult], None]:
         if self.update_strategy == GithubUpdateStategy.COMMENT:
             return self._change_pr_comment
-        else:
-            return self._change_pr_body
+        return self._change_pr_body
 
     def _change_pr_body(self, pull_request: PullRequest, results: RunResult):
         current_body = (pull_request.body.split("----")[0] if pull_request.body else "") + "----"

--- a/tests/reporting/targets/test_github.py
+++ b/tests/reporting/targets/test_github.py
@@ -1,0 +1,23 @@
+from mpyl.reporting.targets.github import PullRequestReporter, GithubUpdateStategy
+from tests.test_resources.test_data import get_config_values
+
+
+class TestGithubReporter:
+    reporter = PullRequestReporter(get_config_values(), update_stategy=GithubUpdateStategy.BODY)
+
+    def test_replace_pr_body_empty(self):
+        assert self.reporter._extract_pr_header(
+            current_body=None
+        ) == f"\n{self.reporter.body_separator}\n"
+
+    def test_replace_pr_body(self):
+        assert self.reporter._extract_pr_header(
+            current_body="body"
+        ) == f"body\n{self.reporter.body_separator}\n"
+
+    def test_replace_pr_body_repeated(self):
+        assert self.reporter._extract_pr_header(
+            current_body=self.reporter._extract_pr_header(
+                current_body="body"
+            )
+        ) == f"body\n{self.reporter.body_separator}\n"

--- a/tests/test_resources/run_properties.yml
+++ b/tests/test_resources/run_properties.yml
@@ -7,7 +7,7 @@ build:
     user_email: !ENV ${BUILD_USER_EMAIL}
   local: !ENV ${LOCAL:true}
   parameters:
-    deploy_target: !ENV ${deployTarget:PullRequest}
+    deploy_target: !ENV ${DEPLOY_TARGET:PullRequest}
   versioning:
     revision: !ENV ${GIT_COMMIT:hash}
     branch: !ENV ${CHANGE_BRANCH}


### PR DESCRIPTION
Monorepo counterpart https://github.com/Vandebron/Vandebron/pull/10546


----
## 📕 [TECH-441](https://vandebron.atlassian.net/browse/TECH-441) Build information should be appended to pull request body ![danielkoves@vandebron.nl](https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24) 

🏗️ Build [10](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-125/10/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀  *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-125.test.nl/)*, *[sbtservice](https://sbtservice-125.test.nl/)*  


[TECH-441]: https://vandebron.atlassian.net/browse/TECH-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ