### PR TITLE
[TECH-394] Add multiple links to the cypress dashboard if multiple su…

### DIFF
--- a/src/mpyl/reporting/formatting/markdown.py
+++ b/src/mpyl/reporting/formatting/markdown.py
@@ -2,14 +2,17 @@
 Markdown run result formatters
 """
 import operator
+import itertools
 
 from junitparser import TestSuite
 
 from ...project import Stage, Project
 from ...steps import Output, ArtifactType
+from ...steps.models import Artifact
 from ...steps.run import RunResult
-from ...steps.steps import StepResult, collect_test_results, collect_test_artifacts
-from ...utilities.junit import TestRunSummary, sum_suites, TEST_RESULTS_URL_KEY
+from ...steps.steps import StepResult
+from ...utilities.junit import TestRunSummary, sum_suites, TEST_RESULTS_URL_KEY, TEST_RESULTS_URL_NAME_KEY, \
+    to_test_suites
 
 
 def summary_to_markdown(summary: TestRunSummary):
@@ -68,16 +71,16 @@ def markdown_for_stage(run_result: RunResult, stage: Stage):
         return ''
 
     result = f"{stage_to_icon(stage)}  {__to_oneliner(step_results, plan)}  \n"
-    test_artifacts = collect_test_artifacts(step_results)
-    test_results = collect_test_results(test_artifacts)
+    test_artifacts = _collect_test_artifacts(step_results)
+    test_results = _collect_test_results(test_artifacts)
 
     if test_results:
         result += to_markdown_test_report(test_results)
+        unique_artifacts = _collection_unique_test_artifacts(test_artifacts)
 
-        artifacts_with_url = (artifact for artifact in test_artifacts if artifact.spec[f'{TEST_RESULTS_URL_KEY}'])
-
-        for artifact_with_url in artifacts_with_url:
-            result += f' [{artifact_with_url.producing_step}]({artifact_with_url.spec[TEST_RESULTS_URL_KEY]})'
+        for unique_artifact in unique_artifacts:
+            result += f' [{unique_artifact.spec[TEST_RESULTS_URL_NAME_KEY]}]' \
+                      f'({unique_artifact.spec[TEST_RESULTS_URL_KEY]})'
 
         result += '  \n'
 
@@ -104,3 +107,30 @@ def run_result_to_markdown(run_result: RunResult) -> str:
 def to_markdown_test_report(suites: list[TestSuite]):
     total_tests = sum_suites(suites)
     return f"{summary_to_markdown(total_tests)}"
+
+
+def _collect_test_artifacts(step_results: list[StepResult]) -> list[Artifact]:
+    return [res.output.produced_artifact for res in step_results if
+            (res.output.produced_artifact and
+             res.output.produced_artifact.artifact_type == ArtifactType.JUNIT_TESTS)]
+
+
+def _collect_test_results(test_artifacts: list[Artifact]) -> list[TestSuite]:
+    suites: list[list[TestSuite]] = list(map(to_test_suites, test_artifacts))
+
+    return list(itertools.chain(*suites))
+
+
+def _collection_unique_test_artifacts(test_artifacts: list[Artifact]) -> list[Artifact]:
+    unique_artifacts: list[Artifact] = []
+    for test_artifact in test_artifacts:
+        duplicate_artifact = next((x for x in unique_artifacts if
+                                   x.spec.get(TEST_RESULTS_URL_KEY, '') == test_artifact.spec.get(TEST_RESULTS_URL_KEY,
+                                                                                                  '')), None)
+        if not duplicate_artifact:
+            test_artifact.spec[TEST_RESULTS_URL_NAME_KEY] = test_artifact.producing_step
+            unique_artifacts.append(test_artifact)
+        elif TEST_RESULTS_URL_NAME_KEY in duplicate_artifact.spec:
+            duplicate_artifact.spec[TEST_RESULTS_URL_NAME_KEY] = 'link'
+
+    return unique_artifacts

--- a/src/mpyl/reporting/formatting/markdown.py
+++ b/src/mpyl/reporting/formatting/markdown.py
@@ -9,7 +9,7 @@ from ...project import Stage, Project
 from ...steps import Output, ArtifactType
 from ...steps.run import RunResult
 from ...steps.steps import StepResult, collect_test_results, collect_test_artifacts
-from ...utilities.junit import TestRunSummary, sum_suites
+from ...utilities.junit import TestRunSummary, sum_suites, TEST_RESULTS_URL_KEY
 
 
 def summary_to_markdown(summary: TestRunSummary):
@@ -74,17 +74,12 @@ def markdown_for_stage(run_result: RunResult, stage: Stage):
     if test_results:
         result += to_markdown_test_report(test_results)
 
-        if stage == Stage.POST_DEPLOY:
-            cypress_result_urls = (artifact.spec['cypress_results_url']
-                                   for artifact in test_artifacts if artifact.spec['cypress_results_url'])
+        artifacts_with_url = (artifact for artifact in test_artifacts if artifact.spec[f'{TEST_RESULTS_URL_KEY}'])
 
-            for cypress_result_url in cypress_result_urls:
-                result += f' [link]({cypress_result_url})'
+        for artifact_with_url in artifacts_with_url:
+            result += f' [{artifact_with_url.producing_step}]({artifact_with_url.spec[TEST_RESULTS_URL_KEY]})'
 
-        elif run_result.run_properties.details.tests_url:
-            result += f' [link]({run_result.run_properties.details.tests_url})'
-
-        result += ' \n'
+        result += '  \n'
 
     return result
 

--- a/src/mpyl/reporting/formatting/markdown.py
+++ b/src/mpyl/reporting/formatting/markdown.py
@@ -75,13 +75,16 @@ def markdown_for_stage(run_result: RunResult, stage: Stage):
         result += to_markdown_test_report(test_results)
 
         if stage == Stage.POST_DEPLOY:
-            test_results_url = next((artifact.spec['cypress_results_url'] for artifact in test_artifacts
-                                    if artifact.spec['cypress_results_url']), '')
-        else:
-            test_results_url = run_result.run_properties.details.tests_url
+            cypress_result_urls = (artifact.spec['cypress_results_url']
+                                   for artifact in test_artifacts if artifact.spec['cypress_results_url'])
 
-        if test_results_url:
-            result += f' [link]({test_results_url}) \n'
+            for cypress_result_url in cypress_result_urls:
+                result += f' [link]({cypress_result_url})'
+
+        elif run_result.run_properties.details.tests_url:
+            result += f' [link]({run_result.run_properties.details.tests_url})'
+
+        result += ' \n'
 
     return result
 

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -11,7 +11,7 @@ from ..models import ArtifactType, Input, Output, input_to_artifact
 from ...project import Stage, Target
 from ...utilities.cypress import CypressConfig
 from ...utilities.docker import execute_with_stream
-from ...utilities.junit import TEST_OUTPUT_PATH_KEY
+from ...utilities.junit import TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 
 
 class CypressTest(Step):
@@ -85,7 +85,7 @@ class CypressTest(Step):
                           produced_artifact=input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS,
                                                               step_input=step_input,
                                                               spec={TEST_OUTPUT_PATH_KEY: volume_path,
-                                                                    "cypress_results_url": cypress_results_url}))
+                                                                    TEST_RESULTS_URL_KEY: cypress_results_url}))
         finally:
             docker_container.stop()
             docker_container.remove()
@@ -93,7 +93,7 @@ class CypressTest(Step):
         return Output(success=True, message=f"Cypress tests for project {step_input.project.name} passed",
                       produced_artifact=input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
                                                           spec={TEST_OUTPUT_PATH_KEY: volume_path,
-                                                                "cypress_results_url": cypress_results_url}))
+                                                                TEST_RESULTS_URL_KEY: cypress_results_url}))
 
     @staticmethod
     def _target_to_test_target(target: Target) -> str:

--- a/src/mpyl/steps/steps.py
+++ b/src/mpyl/steps/steps.py
@@ -1,13 +1,11 @@
 """ Entry point of MPyL. Loads all available Step implementations and triggers their execution based on the specified
 Project and Stage.
 """
-import itertools
 import pkgutil
 from dataclasses import dataclass
 from datetime import datetime
 from logging import Logger
 from typing import Optional
-from unittest import TestSuite
 
 from ruamel.yaml import YAML  # type: ignore
 
@@ -28,7 +26,6 @@ from .test.echo import TestEcho
 from .test.sbt import TestSbt
 from ..project import Project
 from ..project import Stage
-from ..utilities.junit import to_test_suites
 from ..validation import validate
 
 yaml = YAML()
@@ -51,18 +48,6 @@ class StepResult:
     project: Project
     output: Output
     timestamp: datetime = datetime.now()
-
-
-def collect_test_artifacts(step_results: list[StepResult]) -> list[Artifact]:
-    return [res.output.produced_artifact for res in step_results if
-            (res.output.produced_artifact and
-             res.output.produced_artifact.artifact_type == ArtifactType.JUNIT_TESTS)]
-
-
-def collect_test_results(test_artifacts: list[Artifact]) -> list[TestSuite]:
-    suites: list[list[TestSuite]] = list(map(to_test_suites, test_artifacts))
-
-    return list(itertools.chain(*suites))
 
 
 class Steps:

--- a/src/mpyl/steps/test/dockertest.py
+++ b/src/mpyl/steps/test/dockertest.py
@@ -20,7 +20,7 @@ from .. import Step, Meta
 from ..models import Input, Output, ArtifactType, input_to_artifact, Artifact
 from ...project import Stage, Project
 from ...utilities.docker import DockerConfig, build, docker_image_tag, docker_file_path, docker_copy
-from ...utilities.junit import to_test_suites, sum_suites, TEST_OUTPUT_PATH_KEY
+from ...utilities.junit import to_test_suites, sum_suites, TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 
 
 class TestDocker(Step):
@@ -67,4 +67,5 @@ class TestDocker(Step):
         docker_copy(logger=logger, container_path=path_in_container, dst_path=test_result_path, image_name=tag)
 
         return input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
-                                 spec={TEST_OUTPUT_PATH_KEY: f'{test_result_path}'})
+                                 spec={TEST_OUTPUT_PATH_KEY: f'{test_result_path}',
+                                       TEST_RESULTS_URL_KEY: step_input.run_properties.details.tests_url})

--- a/src/mpyl/steps/test/echo.py
+++ b/src/mpyl/steps/test/echo.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from .. import Step, Meta
 from ..models import Input, Output, ArtifactType, input_to_artifact
 from ...project import Stage
-from ...utilities.junit import TEST_OUTPUT_PATH_KEY
+from ...utilities.junit import TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 
 SAMPLE_JUNIT_RESULT = """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -36,5 +36,6 @@ class TestEcho(Step):
         Path(path, "test.xml").write_text(SAMPLE_JUNIT_RESULT, encoding='utf-8')
 
         artifact = input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
-                                     spec={TEST_OUTPUT_PATH_KEY: str(path)})
+                                     spec={TEST_OUTPUT_PATH_KEY: str(path),
+                                           TEST_RESULTS_URL_KEY: step_input.run_properties.details.tests_url})
         return Output(success=True, message=f"Tested {step_input.project.name}", produced_artifact=artifact)

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -8,7 +8,7 @@ from .. import Input, Output, Step
 from ..models import Artifact, input_to_artifact
 from ...project import Stage, Project
 from ...steps import Meta, ArtifactType
-from ...utilities.junit import TEST_OUTPUT_PATH_KEY, to_test_suites, sum_suites
+from ...utilities.junit import TEST_OUTPUT_PATH_KEY, to_test_suites, sum_suites, TEST_RESULTS_URL_KEY
 from ...utilities.sbt import SbtConfig
 from ...utilities.subprocess import custom_check_output
 
@@ -98,4 +98,5 @@ class TestSbt(Step):
     @staticmethod
     def _extract_test_report(project: Project, step_input: Input) -> Artifact:
         return input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
-                                 spec={TEST_OUTPUT_PATH_KEY: f'{project.test_report_path}'})
+                                 spec={TEST_OUTPUT_PATH_KEY: f'{project.test_report_path}',
+                                       TEST_RESULTS_URL_KEY: step_input.run_properties.details.tests_url})

--- a/src/mpyl/utilities/junit/__init__.py
+++ b/src/mpyl/utilities/junit/__init__.py
@@ -8,6 +8,7 @@ from junitparser import JUnitXml, TestSuite
 from ...steps.models import Artifact, ArtifactType
 
 TEST_OUTPUT_PATH_KEY = 'test_output_path'
+TEST_RESULTS_URL_KEY = 'test_results_url'
 
 
 @dataclass(frozen=True)

--- a/src/mpyl/utilities/junit/__init__.py
+++ b/src/mpyl/utilities/junit/__init__.py
@@ -9,6 +9,7 @@ from ...steps.models import Artifact, ArtifactType
 
 TEST_OUTPUT_PATH_KEY = 'test_output_path'
 TEST_RESULTS_URL_KEY = 'test_results_url'
+TEST_RESULTS_URL_NAME_KEY = 'test_results_url_name'
 
 
 @dataclass(frozen=True)

--- a/tests/reporting/__init__.py
+++ b/tests/reporting/__init__.py
@@ -5,7 +5,7 @@ from src.mpyl.project import Stages, Project, Stage
 from src.mpyl.steps.models import Output, Artifact, ArtifactType
 from src.mpyl.steps.run import RunResult
 from src.mpyl.steps.steps import StepResult
-from src.mpyl.utilities.junit import TEST_OUTPUT_PATH_KEY
+from src.mpyl.utilities.junit import TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 from tests import root_test_path
 from tests.test_resources import test_data
 
@@ -42,7 +42,8 @@ def append_results(result: RunResult) -> None:
                                            produced_artifact=
                                            Artifact(artifact_type=ArtifactType.JUNIT_TESTS, revision='revision',
                                                     producing_step='Docker Test',
-                                                    spec={TEST_OUTPUT_PATH_KEY: test_resource_path})),
+                                                    spec={TEST_OUTPUT_PATH_KEY: test_resource_path,
+                                                          TEST_RESULTS_URL_KEY: 'http://localhost/tests'})),
                              timestamp=datetime.fromisoformat('2019-01-04T16:41:45+02:00')))
     result.append(StepResult(stage=Stage.DEPLOY, project=other_project,
                              output=Output(success=True, message='Deploy successful',

--- a/tests/reporting/formatting/test_resources/markdown_run.md
+++ b/tests/reporting/formatting/test_resources/markdown_run.md
@@ -6,5 +6,5 @@ Build failed
 ```
 🏗️  _dockertest_, _test_  
 📋  _test_  
-🧪 51 ❌ 1 💔 0 🙈 0 [link](http://localhost/tests) 
+🧪 51 ❌ 1 💔 0 🙈 0 [Docker Test](http://localhost/tests)  
 🚀  _test_  

--- a/tests/reporting/formatting/test_resources/markdown_run_multiple_urls.md
+++ b/tests/reporting/formatting/test_resources/markdown_run_multiple_urls.md
@@ -1,0 +1,10 @@
+❌ Failed  
+For _dockertest_ at _Stage.BUILD_ 
+
+```
+Build failed
+```
+🏗️  _dockertest_, _test_  
+📋  _dockertest_, _dockertest_, _test_  
+🧪 153 ❌ 3 💔 0 🙈 0 [link](http://localhost/tests) [Cypress](https://cypress.io)  
+🚀  _test_  

--- a/tests/reporting/formatting/test_resources/markdown_run_with_exception.md
+++ b/tests/reporting/formatting/test_resources/markdown_run_with_exception.md
@@ -6,5 +6,5 @@ Something went wrong
 ```
 🏗️  _dockertest_, _test_  
 📋  _test_  
-🧪 51 ❌ 1 💔 0 🙈 0 [link](http://localhost/tests) 
+🧪 51 ❌ 1 💔 0 🙈 0 [Docker Test](http://localhost/tests)  
 🚀  _test_  

--- a/tests/reporting/formatting/test_resources/markdown_run_with_plan.md
+++ b/tests/reporting/formatting/test_resources/markdown_run_with_plan.md
@@ -6,5 +6,5 @@ Build failed
 ```
 🏗️  ~~dockertest~~, *test*  
 📋  *test*  
-🧪 51 ❌ 1 💔 0 🙈 0 [link](http://localhost/tests) 
+🧪 51 ❌ 1 💔 0 🙈 0 [Docker Test](http://localhost/tests)  
 🚀  *[test](https://some.location.com)*  

--- a/tests/reporting/targets/test_resources/markdown_run_slack.md
+++ b/tests/reporting/targets/test_resources/markdown_run_slack.md
@@ -6,5 +6,5 @@ Build failed
 ```
 🏗️  ~dockertest~, *test*  
 📋  *test*  
-🧪 51 ❌ 1 💔 0 🙈 0 <http://localhost/tests|link> 
+🧪 51 ❌ 1 💔 0 🙈 0 <http://localhost/tests|Docker Test>  
 🚀  *<https://some.location.com|test>*  

--- a/tests/reporting/test_markdown_reporting.py
+++ b/tests/reporting/test_markdown_reporting.py
@@ -2,9 +2,9 @@ from datetime import datetime
 
 from src.mpyl.project import Stage
 from src.mpyl.reporting.formatting.markdown import summary_to_markdown, run_result_to_markdown
-from src.mpyl.steps import Output
+from src.mpyl.steps.models import Output, Artifact, ArtifactType
 from src.mpyl.steps.steps import StepResult, ExecutionException
-from src.mpyl.utilities.junit import TestRunSummary
+from src.mpyl.utilities.junit import TestRunSummary, TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 from tests import root_test_path
 from tests.reporting import create_test_result, create_test_result_with_plan, append_results
 from tests.test_resources import test_data
@@ -45,3 +45,22 @@ class TestMarkdownReporting:
         assert round(result.progress_fraction * 100) == 25, 'Should be at one quarter'
         append_results(result)
         assert result.progress_fraction == 1.0, 'Should be 100% at end of run'
+
+    def test_should_combine_duplicate_urls(self):
+        run_result = create_test_result()
+        run_result.append(StepResult(stage=Stage.TEST, project=test_data.get_project(),
+                                     output=Output(success=True, message='Tests successful', produced_artifact=
+                                     Artifact(artifact_type=ArtifactType.JUNIT_TESTS, revision='revision',
+                                              producing_step='Jest',
+                                              spec={TEST_OUTPUT_PATH_KEY: self.test_resource_path,
+                                                    TEST_RESULTS_URL_KEY: 'http://localhost/tests'})),
+                                     timestamp=datetime.fromisoformat('2019-01-04T16:41:24+02:00'))),
+        run_result.append(StepResult(stage=Stage.TEST, project=test_data.get_project(),
+                                     output=Output(success=True, message='Tests successful', produced_artifact=
+                                     Artifact(artifact_type=ArtifactType.JUNIT_TESTS, revision='revision',
+                                              producing_step='Cypress',
+                                              spec={TEST_OUTPUT_PATH_KEY: self.test_resource_path,
+                                                    TEST_RESULTS_URL_KEY: 'https://cypress.io'})),
+                                     timestamp=datetime.fromisoformat('2019-01-04T16:41:24+02:00'))),
+        simple_report = run_result_to_markdown(run_result)
+        assert_roundtrip(self.test_resource_path / "markdown_run_multiple_urls.md", simple_report)


### PR DESCRIPTION
…ites have run

branch: feature/TECH-394-allow-multiple-cypress-result-urls
----
📕 [TECH-394](https://vandebron.atlassian.net/browse/TECH-394) Integrate cypress suites into mpyl ![jorgpost@vandebron.nl](https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png) 
Make sure that certain cypress suites get triggered for certain projects when specified in the project.yml.

🏗️ Build [12](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-138/12/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀  *[cloudfront-service](https://cloudfront-service-138.test.nl/)*, *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-138.test.nl/)*, *[sbtservice](https://sbtservice-138.test.nl/)*  


[TECH-394]: https://vandebron.atlassian.net/browse/TECH-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ