### PR TITLE
[TECH-465] Add an option to select a branch to use for mpyl_config repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ pipeline {
             steps {
                 script {
                     properties([parameters([
-                        string(name: 'BUILD_PARAMS', defaultValue: '--all', description: 'Build parameters passed along with the run. Example: --help or --all')
+                        string(name: 'BUILD_PARAMS', defaultValue: '--all', description: 'Build parameters passed along with the run. Example: --help or --all'),
+                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository')
                     ])])
                     currentBuild.result = 'NOT_BUILT'
                     currentBuild.description = "Parameters can be set now"
@@ -36,7 +37,7 @@ pipeline {
             steps {
                 script {
                     def gitconfig = scm.userRemoteConfigs.getAt(0)
-                    git(branch: 'main',credentialsId: gitconfig.getCredentialsId(), url: 'https://github.com/Vandebron/mpyl_config.git')
+                    git(branch: params.MPYL_CONFIG_BRANCH, credentialsId: gitconfig.getCredentialsId(), url: 'https://github.com/Vandebron/mpyl_config.git')
                     def config = readFile('mpyl_config.yml')
                     git(branch: env.BRANCH_NAME, credentialsId: gitconfig.getCredentialsId(), url: gitconfig.getUrl())
                     writeFile(file: 'mpyl_config.yml', text: config)


### PR DESCRIPTION
branch: feature/TECH-465-investigate-mpyl-config-solution

This allows people to test their mpyl pr's if they also made changes to the config & schema.
----
📕 [TECH-465](https://vandebron.atlassian.net/browse/TECH-465) Investigate better solution for mpyl_config repo ![jorgpost@vandebron.nl](https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png) 
Currently you can’t really update the mpyl_config for mpyl pr builds, because once you push a change the yml validation will fail on other pr builds.

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-139/4/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀  *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-139.test.nl/)*, *[sbtservice](https://sbtservice-139.test.nl/)*  


[TECH-465]: https://vandebron.atlassian.net/browse/TECH-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ