### PR TITLE
[TECH-457] Make sure the build, test and postdeploy stages finish all…

### DIFF
--- a/src/mpyl/cli/commands/build/mpyl.py
+++ b/src/mpyl/cli/commands/build/mpyl.py
@@ -132,7 +132,11 @@ def run_build(accumulator: RunResult, executor: Steps, reporter: Optional[Report
             if reporter:
                 reporter.send_report(accumulator)
 
-            if not result.output.success:
+            if not result.output.success and stage == Stage.DEPLOY:
                 logging.warning(f'Build failed at {stage} for {proj.name}')
                 return accumulator
+
+        if accumulator.failed_result:
+            logging.warning(f'One of the builds failed at {stage}')
+            return accumulator
     return accumulator

--- a/src/mpyl/cli/commands/build/mpyl.py
+++ b/src/mpyl/cli/commands/build/mpyl.py
@@ -133,7 +133,7 @@ def run_build(accumulator: RunResult, executor: Steps, reporter: Optional[Report
                 reporter.send_report(accumulator)
 
             if not result.output.success and stage == Stage.DEPLOY:
-                logging.warning(f'Build failed at {stage} for {proj.name}')
+                logging.warning(f'Deployment failed for {proj.name}')
                 return accumulator
 
         if accumulator.failed_result:


### PR DESCRIPTION
… projects instead of fast failing

branch: feature/TECH-457-finish-stages-instead-of-fast-failing
----
📕 [TECH-457](https://vandebron.atlassian.net/browse/TECH-457) Fix master pipeline ![jorgpost@vandebron.nl](https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png) 
Seems like we broke the master pipeline again

Master pipeline should build all projects and not fail fast

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-142/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀  *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-142.test.nl/)*, *[sbtservice](https://sbtservice-142.test.nl/)*  


[TECH-457]: https://vandebron.atlassian.net/browse/TECH-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ