### PR TITLE
[TECH-394] Add multiprocess support to the cypress step

### DIFF
--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -73,6 +73,9 @@ definitions:
       kubectlConfigPath:
         type: string
         description: 'Path to kubectl config file'
+      ciBuildId:
+        type: string
+        description: 'Build id for cypress dashboard'
     required:
       - cypressSourceCodePath
   Kubernetes:

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -74,7 +74,7 @@ definitions:
         type: string
         description: 'Path to kubectl config file'
       ciBuildId:
-        type: string
+        type: [ string, null ]
         description: 'Build id for cypress dashboard'
     required:
       - cypressSourceCodePath

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -449,8 +449,8 @@ class ChartBuilder:
         docker_image = self.step_input.required_artifact
         if not docker_image or docker_image.artifact_type != ArtifactType.DOCKER_IMAGE:
             raise ValueError(
-                f"Required artifact of type {ArtifactType.DOCKER_IMAGE.name} must be defined"
-            )  # pylint: disable=E1101
+                f"Required artifact of type {ArtifactType.DOCKER_IMAGE.name} must be defined"  # pylint: disable=no-member
+            )
         return docker_image.spec["image"]
 
     def _get_resources(self):

--- a/src/mpyl/steps/models.py
+++ b/src/mpyl/steps/models.py
@@ -125,7 +125,7 @@ class RunProperties:
             details=RunContext.from_configuration(build["run"]),
             target=Target(
                 build["parameters"].get("deploy_target", None)
-                or Target.PULL_REQUEST.value
+                or Target.PULL_REQUEST.value  # pylint: disable=no-member
             ),
             versioning=versioning,
             config=config,

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -2,8 +2,8 @@
 
 import os
 
+from concurrent.futures import ThreadPoolExecutor
 from logging import Logger
-
 from python_on_whales import docker, Container, DockerException
 
 from .. import Step, Meta
@@ -16,159 +16,104 @@ from ...utilities.junit import TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 
 class CypressTest(Step):
     def __init__(self, logger: Logger) -> None:
-        super().__init__(
-            logger,
-            Meta(
-                name="Cypress Test",
-                description="Step to run cypress tests",
-                version="0.0.1",
-                stage=Stage.POST_DEPLOY,
-            ),
-            produced_artifact=ArtifactType.JUNIT_TESTS,
-            required_artifact=ArtifactType.NONE,
-        )
+        super().__init__(logger, Meta(
+            name='Cypress Test',
+            description='Step to run cypress tests',
+            version='0.0.1',
+            stage=Stage.POST_DEPLOY
+        ), produced_artifact=ArtifactType.JUNIT_TESTS, required_artifact=ArtifactType.NONE)
 
     def execute(self, step_input: Input) -> Output:
         if step_input.run_properties.target == Target.PRODUCTION:
-            return Output(
-                success=True, message="Cypress tests are not run on production"
-            )
+            return Output(success=True, message="Cypress tests are not run on production")
 
-        self._logger.info(
-            f"Running cypress tests for project {step_input.project.name}"
-        )
+        self._logger.info(f"Running cypress tests for project {step_input.project.name}")
         cypress_config = CypressConfig.from_config(step_input.run_properties.config)
         volume_path = os.path.join(os.getcwd(), cypress_config.cypress_source_code_path)
 
-        if (
-            step_input.project.dependencies
-            and step_input.project.dependencies.postdeploy
-        ):
-            specs_string = ", ".join(step_input.project.dependencies.postdeploy)
+        if step_input.project.dependencies and step_input.project.dependencies.postdeploy:
+            specs_string = ', '.join(step_input.project.dependencies.postdeploy)
         else:
             raise ValueError("No cypress specs are defined in the project dependencies")
 
         custom_image_tag = "mpyl/cypress"
-        docker.build(
-            context_path=volume_path,
-            tags=[custom_image_tag],
-            file=f"{volume_path}/Dockerfile-mpyl",
-        )
-        docker_container = docker.run(
-            image=custom_image_tag,
-            interactive=True,
-            detach=True,
-            volumes=[
-                (volume_path, "/cypress"),
-                (
-                    os.path.expanduser(cypress_config.kubectl_config_path),
-                    "/root/.kube/config",
-                ),
-            ],
-            workdir="/cypress",
-        )
+        docker.build(context_path=volume_path, tags=[custom_image_tag], file=f"{volume_path}/Dockerfile-mpyl")
+        docker_container = docker.run(image=custom_image_tag, interactive=True, detach=True,
+                                      volumes=[
+                                          (volume_path, "/cypress"),
+                                          (os.path.expanduser(cypress_config.kubectl_config_path), "/root/.kube/config")
+                                      ],
+                                      workdir="/cypress")
         if not isinstance(docker_container, Container):
             raise TypeError("Docker run command should return a container")
 
         reports_folder = f"reports/{step_input.project.name}"
-        artifact = input_to_artifact(
-            artifact_type=ArtifactType.JUNIT_TESTS,
-            step_input=step_input,
-            spec={
-                TEST_OUTPUT_PATH_KEY: f"{volume_path}/{reports_folder}",
-                TEST_RESULTS_URL_KEY: "",
-            },
-        )
+        artifact = input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
+                                     spec={TEST_OUTPUT_PATH_KEY: f"{volume_path}/{reports_folder}",
+                                           TEST_RESULTS_URL_KEY: ''})
 
         try:
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command='bash -c "cp cypress.env.json.example cypress.env.json && '
-                f"sed -i 's/acceptance/"
-                f"{CypressTest._target_to_test_target(step_input.run_properties.target)}"
-                f"/' cypress.env.json && "
-                f"sed -i 's/{{PR_NUMBER}}/{step_input.run_properties.versioning.pr_number}/' "
-                'cypress.env.json"',
-                task_name="Preparing env file",
-            )
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command="yarn install",
-                task_name="Running yarn install",
-            )
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command="yarn cypress install",
-                task_name="Installing cypress",
-            )
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command="yarn cypress verify",
-                task_name="Verifying cypress",
-            )
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command="yarn tsc",
-                task_name="Compiling typescript",
-            )
-            execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command=f"rm -rf {reports_folder}",
-                task_name="Remove old report files",
-            )
+            execute_with_stream(logger=self._logger, container=docker_container,
+                                command='bash -c "cp cypress.env.json.example cypress.env.json && '
+                                        f"sed -i 's/acceptance/"
+                                        f"{CypressTest._target_to_test_target(step_input.run_properties.target)}"
+                                        f"/' cypress.env.json && "
+                                        f"sed -i 's/{{PR_NUMBER}}/{step_input.run_properties.versioning.pr_number}/' "
+                                        'cypress.env.json"',
+                                task_name="Preparing env file")
+            execute_with_stream(logger=self._logger, container=docker_container, command="yarn install",
+                                task_name="Running yarn install")
+            execute_with_stream(logger=self._logger, container=docker_container, command="yarn cypress install",
+                                task_name="Installing cypress")
+            execute_with_stream(logger=self._logger, container=docker_container, command="yarn cypress verify",
+                                task_name="Verifying cypress")
+            execute_with_stream(logger=self._logger, container=docker_container, command="yarn tsc",
+                                task_name="Compiling typescript")
+            execute_with_stream(logger=self._logger, container=docker_container, command=f"rm -rf {reports_folder}",
+                                task_name="Remove old report files")
 
-            run_command = (
-                f'bash -c "yarn cypress run --spec {specs_string} --reporter-options mochaFile='
-                f'"{reports_folder}/[hash].xml" || true"'
-            )
+            run_command = f'bash -c "yarn cypress run --spec {specs_string} --ci-build-id ' \
+                          f'{cypress_config.ci_build_id} --parallel --reporter-options ' \
+                          f'mochaFile="{reports_folder}/[hash].xml" || true"'
             record_key = cypress_config.record_key
             if record_key:
-                run_command = (
-                    f'bash -c "yarn cypress run --spec {specs_string} --reporter-options '
-                    f'"mochaFile={reports_folder}/[hash].xml" --record --key '
-                    f'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
-                )
-            result = execute_with_stream(
-                logger=self._logger,
-                container=docker_container,
-                command=run_command,
-                task_name="Running cypress tests",
-            )
+                run_command = f'bash -c "yarn cypress run --spec {specs_string} --ci-build-id ' \
+                              f'{cypress_config.ci_build_id} --parallel --reporter-options ' \
+                              f'"mochaFile={reports_folder}/[hash].xml" --record --key ' \
+                              f'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+
+            def run_tests():
+                return execute_with_stream(logger=self._logger, container=docker_container, command=run_command,
+                                           task_name="Running cypress tests")
+
+            executor = ThreadPoolExecutor(max_workers=4)
+            thread1 = executor.submit(run_tests)
+            thread2 = executor.submit(run_tests)
+            thread3 = executor.submit(run_tests)
+            thread4 = executor.submit(run_tests)
+            result: list[str] = thread1.result() + thread2.result() + thread3.result() + thread4.result()
 
             for stdout in result:
                 if record_key and "Recorded Run" in stdout:
-                    artifact.spec[TEST_RESULTS_URL_KEY] = stdout.rstrip().rsplit(
-                        "Recorded Run: ", 1
-                    )[1]
+                    artifact.spec[TEST_RESULTS_URL_KEY] = stdout.rstrip().rsplit('Recorded Run: ', 1)[1]
                 if "error Command failed with exit code" in stdout:
                     raise DockerException(command_launched=[run_command], return_code=1)
         except DockerException:
-            return Output(
-                success=False,
-                message=f"Cypress tests for project {step_input.project.name} have one or more failures",
-                produced_artifact=artifact,
-            )
+            return Output(success=False,
+                          message=f"Cypress tests for project {step_input.project.name} have one or more failures",
+                          produced_artifact=artifact)
         finally:
             docker_container.stop()
             docker_container.remove()
 
-        return Output(
-            success=True,
-            message=f"Cypress tests for project {step_input.project.name} passed",
-            produced_artifact=artifact,
-        )
+        return Output(success=True, message=f"Cypress tests for project {step_input.project.name} passed",
+                      produced_artifact=artifact)
 
     @staticmethod
     def _target_to_test_target(target: Target) -> str:
         if target == Target.PULL_REQUEST_BASE:
-            return "test"
+            return 'test'
         if target == Target.ACCEPTANCE:
-            return "acceptance"
+            return 'acceptance'
 
-        return "pr"
+        return 'pr'

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -23,7 +23,7 @@ class CypressTest(Step):
             stage=Stage.POST_DEPLOY
         ), produced_artifact=ArtifactType.JUNIT_TESTS, required_artifact=ArtifactType.NONE)
 
-    def execute(self, step_input: Input) -> Output:
+    def execute(self, step_input: Input) -> Output:  # pylint: disable=too-many-locals
         if step_input.run_properties.target == Target.PRODUCTION:
             return Output(success=True, message="Cypress tests are not run on production")
 

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -49,7 +49,7 @@ class CypressTest(Step):
 
             if record_key:
                 ci_build_id = f"{cypress_config.ci_build_id}-{step_input.project.name}"
-                machines = [1, 2, 3]
+                machines = [1, 2, 3, 4]
                 threads: list[Future] = []
 
                 for machine in machines:

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -16,36 +16,55 @@ from ...utilities.junit import TEST_OUTPUT_PATH_KEY, TEST_RESULTS_URL_KEY
 
 class CypressTest(Step):
     def __init__(self, logger: Logger) -> None:
-        super().__init__(logger, Meta(
-            name='Cypress Test',
-            description='Step to run cypress tests',
-            version='0.0.1',
-            stage=Stage.POST_DEPLOY
-        ), produced_artifact=ArtifactType.JUNIT_TESTS, required_artifact=ArtifactType.NONE)
+        super().__init__(
+            logger,
+            Meta(
+                name="Cypress Test",
+                description="Step to run cypress tests",
+                version="0.0.1",
+                stage=Stage.POST_DEPLOY,
+            ),
+            produced_artifact=ArtifactType.JUNIT_TESTS,
+            required_artifact=ArtifactType.NONE,
+        )
 
     def execute(self, step_input: Input) -> Output:  # pylint: disable=too-many-locals
         if step_input.run_properties.target == Target.PRODUCTION:
-            return Output(success=True, message="Cypress tests are not run on production")
+            return Output(
+                success=True, message="Cypress tests are not run on production"
+            )
 
-        self._logger.info(f"Running cypress tests for project {step_input.project.name}")
+        self._logger.info(
+            f"Running cypress tests for project {step_input.project.name}"
+        )
         cypress_config = CypressConfig.from_config(step_input.run_properties.config)
         volume_path = os.path.join(os.getcwd(), cypress_config.cypress_source_code_path)
 
-        if step_input.project.dependencies and step_input.project.dependencies.postdeploy:
-            specs_string = ','.join(step_input.project.dependencies.postdeploy)
+        if (
+            step_input.project.dependencies
+            and step_input.project.dependencies.postdeploy
+        ):
+            specs_string = ",".join(step_input.project.dependencies.postdeploy)
         else:
             raise ValueError("No cypress specs are defined in the project dependencies")
 
         docker_container = self._get_docker_container(volume_path, cypress_config)
         reports_folder = f"reports/{step_input.project.name}"
-        artifact = input_to_artifact(artifact_type=ArtifactType.JUNIT_TESTS, step_input=step_input,
-                                     spec={TEST_OUTPUT_PATH_KEY: f"{volume_path}/{reports_folder}",
-                                           TEST_RESULTS_URL_KEY: ''})
+        artifact = input_to_artifact(
+            artifact_type=ArtifactType.JUNIT_TESTS,
+            step_input=step_input,
+            spec={
+                TEST_OUTPUT_PATH_KEY: f"{volume_path}/{reports_folder}",
+                TEST_RESULTS_URL_KEY: "",
+            },
+        )
 
         try:
-            self._run_container_preparation_steps(docker_container, step_input, reports_folder)
+            self._run_container_preparation_steps(
+                docker_container, step_input, reports_folder
+            )
             record_key = cypress_config.record_key
-            run_command = ''
+            run_command = ""
 
             if record_key:
                 ci_build_id = f"{cypress_config.ci_build_id}-{step_input.project.name}"
@@ -53,80 +72,143 @@ class CypressTest(Step):
                 threads: list[Future] = []
 
                 for machine in machines:
-                    run_command = f'bash -c "Xvfb :10{machine} & XDG_CONFIG_HOME=/tmp/cyhome{machine} ' \
-                                  f'DISPLAY=:10{machine}  yarn cypress run --spec {specs_string} --ci-build-id ' \
-                                  f'{ci_build_id} --parallel --reporter-options ' \
-                                  f'"mochaFile={reports_folder}/[hash].xml" --record --key ' \
-                                  'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                    run_command = (
+                        f'bash -c "Xvfb :10{machine} & XDG_CONFIG_HOME=/tmp/cyhome{machine} '
+                        f"DISPLAY=:10{machine}  yarn cypress run --spec {specs_string} --ci-build-id "
+                        f"{ci_build_id} --parallel --reporter-options "
+                        f'"mochaFile={reports_folder}/[hash].xml" --record --key '
+                        'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                    )
                     executor = ProcessPoolExecutor(max_workers=len(machines))
-                    threads.append(executor.submit(execute_with_stream, logger=self._logger, container=docker_container,
-                                                   command=run_command, task_name="Running cypress tests parallel",
-                                                   multiprocess=True))
+                    threads.append(
+                        executor.submit(
+                            execute_with_stream,
+                            logger=self._logger,
+                            container=docker_container,
+                            command=run_command,
+                            task_name="Running cypress tests parallel",
+                            multiprocess=True,
+                        )
+                    )
 
-                result: list[str] = list(itertools.chain.from_iterable([thread.result() for thread in threads]))
+                result: list[str] = list(
+                    itertools.chain.from_iterable(
+                        [thread.result() for thread in threads]
+                    )
+                )
             else:
-                run_command = f'bash -c "yarn cypress run --spec {specs_string} --reporter-options ' \
-                              f'mochaFile="{reports_folder}/[hash].xml" || true"'
-                result = execute_with_stream(logger=self._logger, container=docker_container,
-                                             command=run_command, task_name="Running cypress tests")
+                run_command = (
+                    f'bash -c "yarn cypress run --spec {specs_string} --reporter-options '
+                    f'mochaFile="{reports_folder}/[hash].xml" || true"'
+                )
+                result = execute_with_stream(
+                    logger=self._logger,
+                    container=docker_container,
+                    command=run_command,
+                    task_name="Running cypress tests",
+                )
 
             for stdout in result:
                 if record_key and "Recorded Run" in stdout:
-                    artifact.spec[TEST_RESULTS_URL_KEY] = stdout.rstrip().rsplit('Recorded Run: ', 1)[1]
+                    artifact.spec[TEST_RESULTS_URL_KEY] = stdout.rstrip().rsplit(
+                        "Recorded Run: ", 1
+                    )[1]
                 if "error Command failed with exit code" in stdout:
                     raise DockerException(command_launched=[run_command], return_code=1)
         except DockerException:
-            return Output(success=False,
-                          message=f"Cypress tests for project {step_input.project.name} have one or more failures",
-                          produced_artifact=artifact)
+            return Output(
+                success=False,
+                message=f"Cypress tests for project {step_input.project.name} have one or more failures",
+                produced_artifact=artifact,
+            )
         finally:
             docker_container.stop()
             docker_container.remove()
 
-        return Output(success=True, message=f"Cypress tests for project {step_input.project.name} passed",
-                      produced_artifact=artifact)
+        return Output(
+            success=True,
+            message=f"Cypress tests for project {step_input.project.name} passed",
+            produced_artifact=artifact,
+        )
 
     @staticmethod
-    def _get_docker_container(volume_path: str, cypress_config: CypressConfig) -> Container:
+    def _get_docker_container(
+        volume_path: str, cypress_config: CypressConfig
+    ) -> Container:
         custom_image_tag = "mpyl/cypress"
-        docker.build(context_path=volume_path, tags=[custom_image_tag], file=f"{volume_path}/Dockerfile-mpyl")
-        docker_container = docker.run(image=custom_image_tag, interactive=True, detach=True,
-                                      volumes=[
-                                          (volume_path, "/cypress"),
-                                          (os.path.expanduser(cypress_config.kubectl_config_path), "/root/.kube/config")
-                                      ],
-                                      workdir="/cypress")
+        docker.build(
+            context_path=volume_path,
+            tags=[custom_image_tag],
+            file=f"{volume_path}/Dockerfile-mpyl",
+        )
+        docker_container = docker.run(
+            image=custom_image_tag,
+            interactive=True,
+            detach=True,
+            volumes=[
+                (volume_path, "/cypress"),
+                (
+                    os.path.expanduser(cypress_config.kubectl_config_path),
+                    "/root/.kube/config",
+                ),
+            ],
+            workdir="/cypress",
+        )
         if not isinstance(docker_container, Container):
             raise TypeError("Docker run command should return a container")
 
         return docker_container
 
-    def _run_container_preparation_steps(self, docker_container: Container, step_input: Input,
-                                         reports_folder: str) -> None:
-        execute_with_stream(logger=self._logger, container=docker_container,
-                            command=f"rm -rf {reports_folder} dist", task_name="Remove old files")
-        execute_with_stream(logger=self._logger, container=docker_container,
-                            command='bash -c "cp cypress.env.json.example cypress.env.json && '
-                                    f"sed -i 's/acceptance/"
-                                    f"{CypressTest._target_to_test_target(step_input.run_properties.target)}"
-                                    f"/' cypress.env.json && "
-                                    f"sed -i 's/{{PR_NUMBER}}/{step_input.run_properties.versioning.pr_number}/' "
-                                    'cypress.env.json"',
-                            task_name="Preparing env file")
-        execute_with_stream(logger=self._logger, container=docker_container, command="yarn install",
-                            task_name="Running yarn install")
-        execute_with_stream(logger=self._logger, container=docker_container, command="yarn cypress install",
-                            task_name="Installing cypress")
-        execute_with_stream(logger=self._logger, container=docker_container, command="yarn cypress verify",
-                            task_name="Verifying cypress")
-        execute_with_stream(logger=self._logger, container=docker_container, command="yarn tsc",
-                            task_name="Compiling typescript")
+    def _run_container_preparation_steps(
+        self, docker_container: Container, step_input: Input, reports_folder: str
+    ) -> None:
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command=f"rm -rf {reports_folder} dist",
+            task_name="Remove old files",
+        )
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command='bash -c "cp cypress.env.json.example cypress.env.json && '
+            f"sed -i 's/acceptance/"
+            f"{CypressTest._target_to_test_target(step_input.run_properties.target)}"
+            f"/' cypress.env.json && "
+            f"sed -i 's/{{PR_NUMBER}}/{step_input.run_properties.versioning.pr_number}/' "
+            'cypress.env.json"',
+            task_name="Preparing env file",
+        )
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command="yarn install",
+            task_name="Running yarn install",
+        )
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command="yarn cypress install",
+            task_name="Installing cypress",
+        )
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command="yarn cypress verify",
+            task_name="Verifying cypress",
+        )
+        execute_with_stream(
+            logger=self._logger,
+            container=docker_container,
+            command="yarn tsc",
+            task_name="Compiling typescript",
+        )
 
     @staticmethod
     def _target_to_test_target(target: Target) -> str:
         if target == Target.PULL_REQUEST_BASE:
-            return 'test'
+            return "test"
         if target == Target.ACCEPTANCE:
-            return 'acceptance'
+            return "acceptance"
 
-        return 'pr'
+        return "pr"

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -1,8 +1,8 @@
 """ Step that runs relevant cypress tests in the post deploy stage """
-import multiprocessing
+import itertools
 import os
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, Future
 from logging import Logger
 from python_on_whales import docker, Container, DockerException
 
@@ -23,7 +23,7 @@ class CypressTest(Step):
             stage=Stage.POST_DEPLOY
         ), produced_artifact=ArtifactType.JUNIT_TESTS, required_artifact=ArtifactType.NONE)
 
-    def execute(self, step_input: Input) -> Output:  # pylint: disable=too-many-locals
+    def execute(self, step_input: Input) -> Output:  # pylint: disable=too-many-locals, too-many-branches
         if step_input.run_properties.target == Target.PRODUCTION:
             return Output(success=True, message="Cypress tests are not run on production")
 
@@ -54,6 +54,8 @@ class CypressTest(Step):
 
         try:
             execute_with_stream(logger=self._logger, container=docker_container,
+                                command=f"rm -rf {reports_folder} dist", task_name="Remove old files")
+            execute_with_stream(logger=self._logger, container=docker_container,
                                 command='bash -c "cp cypress.env.json.example cypress.env.json && '
                                         f"sed -i 's/acceptance/"
                                         f"{CypressTest._target_to_test_target(step_input.run_properties.target)}"
@@ -69,30 +71,32 @@ class CypressTest(Step):
                                 task_name="Verifying cypress")
             execute_with_stream(logger=self._logger, container=docker_container, command="yarn tsc",
                                 task_name="Compiling typescript")
-            execute_with_stream(logger=self._logger, container=docker_container, command=f"rm -rf {reports_folder}",
-                                task_name="Remove old report files")
 
-            run_command = f'bash -c "yarn cypress run --spec {specs_string} --reporter-options ' \
-                          f'mochaFile="{reports_folder}/[hash].xml" || true"'
             record_key = cypress_config.record_key
+            run_command = ''
+
             if record_key:
                 ci_build_id = f"{cypress_config.ci_build_id}-{step_input.project.name}"
-                run_command = f'bash -c "yarn cypress run --spec {specs_string} --ci-build-id ' \
-                              f'{ci_build_id} --parallel --reporter-options ' \
-                              f'"mochaFile={reports_folder}/[hash].xml" --record --key ' \
-                              f'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                machines = [1, 2, 3]
+                threads: list[Future] = []
 
-            def run_tests():
-                return execute_with_stream(logger=self._logger, container=docker_container, command=run_command,
-                                           task_name="Running cypress tests")
+                for machine in machines:
+                    run_command = f'bash -c "Xvfb :10{machine} & XDG_CONFIG_HOME=/tmp/cyhome{machine} ' \
+                                  f'DISPLAY=:10{machine}  yarn cypress run --spec {specs_string} --ci-build-id ' \
+                                  f'{ci_build_id} --parallel --reporter-options ' \
+                                  f'"mochaFile={reports_folder}/[hash].xml" --record --key ' \
+                                  'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                    executor = ProcessPoolExecutor(max_workers=len(machines))
+                    threads.append(executor.submit(execute_with_stream, logger=self._logger, container=docker_container,
+                                                   command=run_command, task_name="Running cypress tests parallel",
+                                                   multiprocess=True))
 
-            print('-------- number of cpus: ', os.cpu_count())
-            print('-------- number of cpus: ', multiprocessing.cpu_count())
-            executor = ThreadPoolExecutor(max_workers=3)
-            thread1 = executor.submit(run_tests)
-            thread2 = executor.submit(run_tests)
-            thread3 = executor.submit(run_tests)
-            result: list[str] = thread1.result() + thread2.result() + thread3.result()
+                result: list[str] = list(itertools.chain.from_iterable([thread.result() for thread in threads]))
+            else:
+                run_command = f'bash -c "yarn cypress run --spec {specs_string} --reporter-options ' \
+                              f'mochaFile="{reports_folder}/[hash].xml" || true"'
+                result = execute_with_stream(logger=self._logger, container=docker_container,
+                                             command=run_command, task_name="Running cypress tests")
 
             for stdout in result:
                 if record_key and "Recorded Run" in stdout:

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -72,13 +72,14 @@ class CypressTest(Step):
             execute_with_stream(logger=self._logger, container=docker_container, command=f"rm -rf {reports_folder}",
                                 task_name="Remove old report files")
 
+            ci_build_id = f"{cypress_config.ci_build_id}-{step_input.project.name}"
             run_command = f'bash -c "yarn cypress run --spec {specs_string} --ci-build-id ' \
-                          f'{cypress_config.ci_build_id} --parallel --reporter-options ' \
+                          f'{ci_build_id} --parallel --reporter-options ' \
                           f'mochaFile="{reports_folder}/[hash].xml" || true"'
             record_key = cypress_config.record_key
             if record_key:
                 run_command = f'bash -c "yarn cypress run --spec {specs_string} --ci-build-id ' \
-                              f'{cypress_config.ci_build_id} --parallel --reporter-options ' \
+                              f'{ci_build_id} --parallel --reporter-options ' \
                               f'"mochaFile={reports_folder}/[hash].xml" --record --key ' \
                               f'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
 

--- a/src/mpyl/utilities/cypress/__init__.py
+++ b/src/mpyl/utilities/cypress/__init__.py
@@ -13,12 +13,17 @@ class CypressConfig:
 
     @staticmethod
     def from_config(config: dict):
-        cypress_config = config.get('cypress')
+        cypress_config = config.get("cypress")
         if not cypress_config:
-            raise KeyError('Cypress section needs to be defined in mpyl_config.yml')
+            raise KeyError("Cypress section needs to be defined in mpyl_config.yml")
 
-        return CypressConfig(cypress_source_code_path=cypress_config.get('cypressSourceCodePath'),
-                             record_key=cypress_config.get('recordKey'),
-                             kubectl_config_path=cypress_config.get('kubectlConfigPath', '~/.kube/config'),
-                             ci_build_id=cypress_config.get('ciBuildId',
-                                                            f"local{str(uuid.uuid4().int)[:10]}").replace(" ", ""))
+        return CypressConfig(
+            cypress_source_code_path=cypress_config.get("cypressSourceCodePath"),
+            record_key=cypress_config.get("recordKey"),
+            kubectl_config_path=cypress_config.get(
+                "kubectlConfigPath", "~/.kube/config"
+            ),
+            ci_build_id=cypress_config.get(
+                "ciBuildId", f"local{str(uuid.uuid4().int)[:10]}"
+            ).replace(" ", ""),
+        )

--- a/src/mpyl/utilities/cypress/__init__.py
+++ b/src/mpyl/utilities/cypress/__init__.py
@@ -19,4 +19,4 @@ class CypressConfig:
         return CypressConfig(cypress_source_code_path=cypress_config.get('cypressSourceCodePath'),
                              record_key=cypress_config.get('recordKey'),
                              kubectl_config_path=cypress_config.get('kubectlConfigPath', '~/.kube/config'),
-                             ci_build_id=cypress_config.get('ciBuildId', 'local-1'))
+                             ci_build_id=cypress_config.get('ciBuildId', 'local-1').replace(" ", ""))

--- a/src/mpyl/utilities/cypress/__init__.py
+++ b/src/mpyl/utilities/cypress/__init__.py
@@ -1,4 +1,5 @@
 """Configuration required for running cypress"""
+import uuid
 from dataclasses import dataclass
 from typing import Optional
 
@@ -8,7 +9,7 @@ class CypressConfig:
     cypress_source_code_path: str
     kubectl_config_path: str
     record_key: Optional[str]
-    ci_build_id: str
+    ci_build_id: Optional[str]
 
     @staticmethod
     def from_config(config: dict):
@@ -19,4 +20,5 @@ class CypressConfig:
         return CypressConfig(cypress_source_code_path=cypress_config.get('cypressSourceCodePath'),
                              record_key=cypress_config.get('recordKey'),
                              kubectl_config_path=cypress_config.get('kubectlConfigPath', '~/.kube/config'),
-                             ci_build_id=cypress_config.get('ciBuildId', 'local-1').replace(" ", ""))
+                             ci_build_id=cypress_config.get('ciBuildId',
+                                                            f"local{str(uuid.uuid4().int)[:10]}").replace(" ", ""))

--- a/src/mpyl/utilities/cypress/__init__.py
+++ b/src/mpyl/utilities/cypress/__init__.py
@@ -8,17 +8,15 @@ class CypressConfig:
     cypress_source_code_path: str
     kubectl_config_path: str
     record_key: Optional[str]
+    ci_build_id: str
 
     @staticmethod
     def from_config(config: dict):
-        cypress_config = config.get("cypress")
+        cypress_config = config.get('cypress')
         if not cypress_config:
-            raise KeyError("Cypress section needs to be defined in mpyl_config.yml")
+            raise KeyError('Cypress section needs to be defined in mpyl_config.yml')
 
-        return CypressConfig(
-            cypress_source_code_path=cypress_config.get("cypressSourceCodePath"),
-            record_key=cypress_config.get("recordKey"),
-            kubectl_config_path=cypress_config.get(
-                "kubectlConfigPath", "~/.kube/config"
-            ),
-        )
+        return CypressConfig(cypress_source_code_path=cypress_config.get('cypressSourceCodePath'),
+                             record_key=cypress_config.get('recordKey'),
+                             kubectl_config_path=cypress_config.get('kubectlConfigPath', '~/.kube/config'),
+                             ci_build_id=cypress_config.get('ciBuildId', 'local-1'))

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -3,7 +3,6 @@ import logging
 import shlex
 
 from dataclasses import dataclass
-from itertools import tee
 from logging import Logger
 from traceback import print_exc
 from typing import Dict, Optional, Iterator, cast, Union
@@ -11,7 +10,7 @@ import shutil
 from pathlib import Path
 from python_on_whales import docker, Image, Container, DockerException
 from python_on_whales.exceptions import NoSuchContainer
-from rich.text import Text
+from rich.logging import RichHandler
 
 from ..logging import try_parse_ansi
 from ...project import Project
@@ -29,13 +28,11 @@ class DockerComposeConfig:
 
     @staticmethod
     def from_yaml(config: dict):
-        compose_config = config.get("docker", {}).get("compose")
+        compose_config = config.get('docker', {}).get('compose')
         if not compose_config:
-            raise KeyError("docker.compose needs to be defined")
-        return DockerComposeConfig(
-            period_seconds=int(compose_config["periodSeconds"]),
-            failure_threshold=int(compose_config["failureThreshold"]),
-        )
+            raise KeyError('docker.compose needs to be defined')
+        return DockerComposeConfig(period_seconds=int(compose_config['periodSeconds']),
+                                   failure_threshold=int(compose_config['failureThreshold']))
 
 
 @dataclass(frozen=True)
@@ -51,69 +48,60 @@ class DockerConfig:
     @staticmethod
     def from_dict(config: Dict):
         try:
-            registry: Dict = config["docker"]["registry"]
-            build_config: Dict = config["docker"]["build"]
+            registry: Dict = config['docker']['registry']
+            build_config: Dict = config['docker']['build']
             return DockerConfig(
-                host_name=registry["hostName"],
-                user_name=registry["userName"],
-                password=registry["password"],
-                root_folder=build_config["rootFolder"],
-                build_target=build_config.get("buildTarget", None),
-                test_target=build_config.get("testTarget", None),
-                docker_file_name=build_config["dockerFileName"],
+                host_name=registry['hostName'],
+                user_name=registry['userName'],
+                password=registry['password'],
+                root_folder=build_config['rootFolder'],
+                build_target=build_config.get('buildTarget', None),
+                test_target=build_config.get('testTarget', None),
+                docker_file_name=build_config['dockerFileName']
             )
         except KeyError as exc:
-            raise KeyError(f"Docker config could not be loaded from {config}") from exc
+            raise KeyError(f'Docker config could not be loaded from {config}') from exc
 
 
-def execute_with_stream(
-    logger: Logger, container: Container, command: str, task_name: str
-):
-    result = cast(
-        Iterator[tuple[str, bytes]],
-        container.execute(command=shlex.split(command), stream=True),
-    )
+def execute_with_stream(logger: Logger, container: Container, command: str, task_name: str, multiprocess: bool = False):
+    if multiprocess:  # Logger settings need to be re-applied in each process
+        logger.setLevel(logging.INFO)
+        logger.addHandler(RichHandler())
+
+    result = cast(Iterator[tuple[str, bytes]], container.execute(command=shlex.split(command), stream=True))
     result_list = stream_docker_logging(logger, result, task_name)
+
+    logger.handlers.clear()
 
     return result_list
 
 
-def stream_docker_logging(
-    logger: Logger,
-    generator: Union[Iterator[str], Iterator[tuple[str, bytes]]],
-    task_name: str,
-    level=logging.INFO,
-) -> list[str]:
+def stream_docker_logging(logger: Logger, generator: Union[Iterator[str], Iterator[tuple[str, bytes]]], task_name: str,
+                          level=logging.INFO) -> list[str]:
     copied_logs = []
 
     while True:
         try:
             next_item = next(generator)
-            log_line = (
-                next_item[1].decode(errors="replace")
-                if isinstance(next_item, tuple)
-                else next_item
-            )
+            log_line = next_item[1].decode(errors="replace") if isinstance(next_item, tuple) else next_item
             copied_logs.append(log_line)
             logger.log(level, try_parse_ansi(log_line))
         except StopIteration:
-            logger.info(f"{task_name} complete.")
+            logger.info(f'{task_name} complete.')
             return copied_logs
 
 
 def docker_image_tag(step_input: Input):
     git = step_input.run_properties.versioning
     tag = git.tag if git.tag else f"pr-{git.pr_number}"
-    return f"{step_input.project.name.lower()}:{tag}".replace("/", "_")
+    return f"{step_input.project.name.lower()}:{tag}".replace('/', '_')
 
 
 def docker_file_path(project: Project, docker_config: DockerConfig):
-    return f"{project.deployment_path}/{docker_config.docker_file_name}"
+    return f'{project.deployment_path}/{docker_config.docker_file_name}'
 
 
-def docker_copy(
-    logger: Logger, container_path: str, dst_path: str, container: Container
-):
+def docker_copy(logger: Logger, container_path: str, dst_path: str, container: Container):
     """
     Copies the contents of the specified path within the container to a locally created destination
 
@@ -126,24 +114,20 @@ def docker_copy(
     Path(dst_path).mkdir(parents=True, exist_ok=True)
 
     if not docker.container.exists(container.id):
-        raise ValueError(f"Container {container.id} does not exist")
+        raise ValueError(f'Container {container.id} does not exist')
 
     logger.info(
         f"Copying contents from container {container.id} at "
         f"path {container_path} to host at {dst_path}"
     )
     try:
-        docker.copy(f"{container.id}:{container_path}", dst_path)
+        docker.copy(f'{container.id}:{container_path}', dst_path)
     except NoSuchContainer as exc:
-        logger.warning(
-            f"Could not find data in container {container.name} at expected location {container_path}"
-        )
+        logger.warning(f'Could not find data in container {container.name} at expected location {container_path}')
         raise exc
 
 
-def build(
-    logger: Logger, root_path: str, file_path: str, image_tag: str, target: str
-) -> bool:
+def build(logger: Logger, root_path: str, file_path: str, image_tag: str, target: str) -> bool:
     """
     :param logger: the logger
     :param root_path: the root path to which `docker_file_path` is relative
@@ -155,25 +139,16 @@ def build(
     logger.info(f"Building docker image with {file_path} and target {target}")
 
     try:
-        logs = docker.buildx.build(
-            context_path=root_path,
-            file=file_path,
-            tags=[image_tag],
-            target=target,
-            stream_logs=True,
-        )
+        logs = docker.buildx.build(context_path=root_path, file=file_path, tags=[image_tag], target=target,
+                                   stream_logs=True)
         if logs is not None and not isinstance(logs, Image):
-            stream_docker_logging(
-                logger=logger, generator=logs, task_name=f"Build {file_path}:{target}"
-            )
+            stream_docker_logging(logger=logger, generator=logs, task_name=f'Build {file_path}:{target}')
         logger.debug(logs)
         return True
 
     except DockerException as exc:
         command = " ".join(exc.docker_command)
-        logger.warning(
-            f"Docker build failed with command {command} and exit code {exc.return_code}"
-        )
+        logger.warning(f"Docker build failed with command {command} and exit code {exc.return_code}")
         return False
     except Exception as exc:  # pylint: disable=broad-exception-caught
         print(f"Docker build failed with {exc.__class__.__name__}")
@@ -183,11 +158,8 @@ def build(
 
 def login(logger: Logger, docker_config: DockerConfig) -> None:
     logger.info(f"Logging in with user '{docker_config.user_name}'")
-    docker.login(
-        server=f"https://{docker_config.host_name}",
-        username=docker_config.user_name,
-        password=docker_config.password,
-    )
+    docker.login(server=f'https://{docker_config.host_name}', username=docker_config.user_name,
+                 password=docker_config.password)
     logger.debug(f"Logged in as '{docker_config.user_name}'")
 
 

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -28,11 +28,13 @@ class DockerComposeConfig:
 
     @staticmethod
     def from_yaml(config: dict):
-        compose_config = config.get('docker', {}).get('compose')
+        compose_config = config.get("docker", {}).get("compose")
         if not compose_config:
-            raise KeyError('docker.compose needs to be defined')
-        return DockerComposeConfig(period_seconds=int(compose_config['periodSeconds']),
-                                   failure_threshold=int(compose_config['failureThreshold']))
+            raise KeyError("docker.compose needs to be defined")
+        return DockerComposeConfig(
+            period_seconds=int(compose_config["periodSeconds"]),
+            failure_threshold=int(compose_config["failureThreshold"]),
+        )
 
 
 @dataclass(frozen=True)
@@ -48,27 +50,36 @@ class DockerConfig:
     @staticmethod
     def from_dict(config: Dict):
         try:
-            registry: Dict = config['docker']['registry']
-            build_config: Dict = config['docker']['build']
+            registry: Dict = config["docker"]["registry"]
+            build_config: Dict = config["docker"]["build"]
             return DockerConfig(
-                host_name=registry['hostName'],
-                user_name=registry['userName'],
-                password=registry['password'],
-                root_folder=build_config['rootFolder'],
-                build_target=build_config.get('buildTarget', None),
-                test_target=build_config.get('testTarget', None),
-                docker_file_name=build_config['dockerFileName']
+                host_name=registry["hostName"],
+                user_name=registry["userName"],
+                password=registry["password"],
+                root_folder=build_config["rootFolder"],
+                build_target=build_config.get("buildTarget", None),
+                test_target=build_config.get("testTarget", None),
+                docker_file_name=build_config["dockerFileName"],
             )
         except KeyError as exc:
-            raise KeyError(f'Docker config could not be loaded from {config}') from exc
+            raise KeyError(f"Docker config could not be loaded from {config}") from exc
 
 
-def execute_with_stream(logger: Logger, container: Container, command: str, task_name: str, multiprocess: bool = False):
+def execute_with_stream(
+    logger: Logger,
+    container: Container,
+    command: str,
+    task_name: str,
+    multiprocess: bool = False,
+):
     if multiprocess:  # Logger settings need to be re-applied in each process
         logger.setLevel(logging.INFO)
         logger.addHandler(RichHandler())
 
-    result = cast(Iterator[tuple[str, bytes]], container.execute(command=shlex.split(command), stream=True))
+    result = cast(
+        Iterator[tuple[str, bytes]],
+        container.execute(command=shlex.split(command), stream=True),
+    )
     result_list = stream_docker_logging(logger, result, task_name)
 
     logger.handlers.clear()
@@ -76,32 +87,42 @@ def execute_with_stream(logger: Logger, container: Container, command: str, task
     return result_list
 
 
-def stream_docker_logging(logger: Logger, generator: Union[Iterator[str], Iterator[tuple[str, bytes]]], task_name: str,
-                          level=logging.INFO) -> list[str]:
+def stream_docker_logging(
+    logger: Logger,
+    generator: Union[Iterator[str], Iterator[tuple[str, bytes]]],
+    task_name: str,
+    level=logging.INFO,
+) -> list[str]:
     copied_logs = []
 
     while True:
         try:
             next_item = next(generator)
-            log_line = next_item[1].decode(errors="replace") if isinstance(next_item, tuple) else next_item
+            log_line = (
+                next_item[1].decode(errors="replace")
+                if isinstance(next_item, tuple)
+                else next_item
+            )
             copied_logs.append(log_line)
             logger.log(level, try_parse_ansi(log_line))
         except StopIteration:
-            logger.info(f'{task_name} complete.')
+            logger.info(f"{task_name} complete.")
             return copied_logs
 
 
 def docker_image_tag(step_input: Input):
     git = step_input.run_properties.versioning
     tag = git.tag if git.tag else f"pr-{git.pr_number}"
-    return f"{step_input.project.name.lower()}:{tag}".replace('/', '_')
+    return f"{step_input.project.name.lower()}:{tag}".replace("/", "_")
 
 
 def docker_file_path(project: Project, docker_config: DockerConfig):
-    return f'{project.deployment_path}/{docker_config.docker_file_name}'
+    return f"{project.deployment_path}/{docker_config.docker_file_name}"
 
 
-def docker_copy(logger: Logger, container_path: str, dst_path: str, container: Container):
+def docker_copy(
+    logger: Logger, container_path: str, dst_path: str, container: Container
+):
     """
     Copies the contents of the specified path within the container to a locally created destination
 
@@ -114,20 +135,24 @@ def docker_copy(logger: Logger, container_path: str, dst_path: str, container: C
     Path(dst_path).mkdir(parents=True, exist_ok=True)
 
     if not docker.container.exists(container.id):
-        raise ValueError(f'Container {container.id} does not exist')
+        raise ValueError(f"Container {container.id} does not exist")
 
     logger.info(
         f"Copying contents from container {container.id} at "
         f"path {container_path} to host at {dst_path}"
     )
     try:
-        docker.copy(f'{container.id}:{container_path}', dst_path)
+        docker.copy(f"{container.id}:{container_path}", dst_path)
     except NoSuchContainer as exc:
-        logger.warning(f'Could not find data in container {container.name} at expected location {container_path}')
+        logger.warning(
+            f"Could not find data in container {container.name} at expected location {container_path}"
+        )
         raise exc
 
 
-def build(logger: Logger, root_path: str, file_path: str, image_tag: str, target: str) -> bool:
+def build(
+    logger: Logger, root_path: str, file_path: str, image_tag: str, target: str
+) -> bool:
     """
     :param logger: the logger
     :param root_path: the root path to which `docker_file_path` is relative
@@ -139,16 +164,25 @@ def build(logger: Logger, root_path: str, file_path: str, image_tag: str, target
     logger.info(f"Building docker image with {file_path} and target {target}")
 
     try:
-        logs = docker.buildx.build(context_path=root_path, file=file_path, tags=[image_tag], target=target,
-                                   stream_logs=True)
+        logs = docker.buildx.build(
+            context_path=root_path,
+            file=file_path,
+            tags=[image_tag],
+            target=target,
+            stream_logs=True,
+        )
         if logs is not None and not isinstance(logs, Image):
-            stream_docker_logging(logger=logger, generator=logs, task_name=f'Build {file_path}:{target}')
+            stream_docker_logging(
+                logger=logger, generator=logs, task_name=f"Build {file_path}:{target}"
+            )
         logger.debug(logs)
         return True
 
     except DockerException as exc:
         command = " ".join(exc.docker_command)
-        logger.warning(f"Docker build failed with command {command} and exit code {exc.return_code}")
+        logger.warning(
+            f"Docker build failed with command {command} and exit code {exc.return_code}"
+        )
         return False
     except Exception as exc:  # pylint: disable=broad-exception-caught
         print(f"Docker build failed with {exc.__class__.__name__}")
@@ -158,8 +192,11 @@ def build(logger: Logger, root_path: str, file_path: str, image_tag: str, target
 
 def login(logger: Logger, docker_config: DockerConfig) -> None:
     logger.info(f"Logging in with user '{docker_config.user_name}'")
-    docker.login(server=f'https://{docker_config.host_name}', username=docker_config.user_name,
-                 password=docker_config.password)
+    docker.login(
+        server=f"https://{docker_config.host_name}",
+        username=docker_config.user_name,
+        password=docker_config.password,
+    )
     logger.debug(f"Logged in as '{docker_config.user_name}'")
 
 


### PR DESCRIPTION
This makes the cypress runs almost as fast as the nightly runs that use jenkins matrixes. Increasing performance on longer suites more than 2x.


branch: feature/TECH-394-implement-parallel-runs

----
### 📕 [TECH-394](https://vandebron.atlassian.net/browse/TECH-394) Integrate cypress suites into mpyl <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Make sure that certain cypress suites get triggered for certain projects when specified in the project.yml.

🏗️ Build [10](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-144/10/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-144.test.nl/)*, *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-144.test.nl/)*, *[sbtservice](https://sbtservice-144.test.nl/)*  


[TECH-394]: https://vandebron.atlassian.net/browse/TECH-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ