### PR TITLE
Prepare for customizable stages

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,91 +5,155 @@ on:
     branches-ignore: [ 'main' ]
 
 jobs:
-  Build_Package:
+  Lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      id: cache-dependencies
-      with:
-        python-version: '3.9'
-        cache: 'pipenv'
-        cache-dependency-path: |
-          Pipfile.lock
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: cache-dependencies
+        with:
+          python-version: '3.9'
+          cache: 'pipenv'
+          cache-dependency-path: |
+            Pipfile.lock
 
-    - name: Install pipenv
-      run: pip install pipenv
+      - name: Install pipenv
+        run: pip install pipenv
 
-    - name: Install dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: pipenv install -d --deploy
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: pipenv install -d --deploy
 
-    - name: Run lint
-      run: pipenv run lint
+      - name: Run lint
+        run: pipenv run lint
 
-    - name: Install Types
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: pipenv run install-types
+  TypeCheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: cache-dependencies
+        with:
+          python-version: '3.9'
+          cache: 'pipenv'
+          cache-dependency-path: |
+            Pipfile.lock
 
-    - name: Validate Types
-      run: pipenv run check-types
+      - name: Install pipenv
+        run: pip install pipenv
 
-    - name: Test
-      run: pipenv run test-ci
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: pipenv install -d --deploy
 
-    - name: Validate Config Example
-      run: pipenv run validate-config-example
+      - name: Run lint
+        run: pipenv run lint
 
-    - name: Coverage to xml
-      run: pipenv run test-ci-coverage
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: cache-dependencies
+        with:
+          python-version: '3.9'
+          cache: 'pipenv'
+          cache-dependency-path: |
+            Pipfile.lock
 
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: build/coverage.xml
-        badge: true
-        fail_below_min: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '70 99'
+      - name: Install pipenv
+        run: pip install pipenv
 
-    - name: Find PR number
-      uses: jwalton/gh-find-current-pr@v1
-      id: findPr
-      if: github.ref_name != 'main'
-      with:
-        state: open
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: pipenv install -d --deploy
 
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        number: ${{ steps.findPr.outputs.pr }}
-        path: code-coverage-results.md
+      - name: Test
+        run: pipenv run test-ci
 
-    - name: Build
-      if: github.ref_name != 'main'
-      env:
-        PIPENV_DONT_LOAD_ENV: true
-        MPYL_VERSION: "${{ steps.findPr.outputs.pr }}.${{ github.run_number }}"
-      run: pipenv run build
+      - name: Validate Config Example
+        run: pipenv run validate-config-example
 
-    - name: Publish package
-      id: publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-      run: pipenv run publish
+      - name: Coverage to xml
+        run: pipenv run test-ci-coverage
 
-    - name: Comment Published package
-      uses: thollander/actions-comment-pull-request@v2
-      if: success()
-      with:
-        pr_number: ${{ steps.findPr.outputs.pr }}
-        message: |
-          New release `${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)
-        reactions: rocket
-        comment_tag: execution
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: build/coverage.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '70 99'
+
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        if: github.ref_name != 'main'
+        with:
+          state: open
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.findPr.outputs.pr }}
+          path: code-coverage-results.md
+
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: [Lint, TypeCheck, Test]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        id: cache-dependencies
+        with:
+          python-version: '3.9'
+          cache: 'pipenv'
+          cache-dependency-path: |
+            Pipfile.lock
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: pipenv install -d --deploy
+
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        if: github.ref_name != 'main'
+        with:
+          state: open
+
+      - name: Build
+        if: github.ref_name != 'main'
+        env:
+          PIPENV_DONT_LOAD_ENV: true
+          MPYL_VERSION: "${{ steps.findPr.outputs.pr }}.${{ github.run_number }}"
+        run: pipenv run build
+
+      - name: Publish package
+        id: publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        run: pipenv run publish
+
+      - name: Comment Published package
+        uses: thollander/actions-comment-pull-request@v2
+        if: success()
+        with:
+          pr_number: ${{ steps.findPr.outputs.pr }}
+          message: |
+            New release `${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)
+          reactions: rocket
+          comment_tag: execution
+
+      - name: Report deployed pacakge
+        run: echo '### New release! 🚀`${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -46,8 +46,8 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: pipenv install -d --deploy
 
-      - name: Run lint
-        run: pipenv run lint
+      - name: Check types
+        run: pipenv run check-types
 
   Test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,5 +1,4 @@
 name: build
-
 on:
   push:
     branches-ignore: [ 'main' ]
@@ -103,7 +102,7 @@ jobs:
           number: ${{ steps.findPr.outputs.pr }}
           path: code-coverage-results.md
 
-  Deploy:
+  Build_Package:
     runs-on: ubuntu-latest
     needs: [Lint, TypeCheck, Test]
     steps:

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -7,3 +7,4 @@
 /dataSources/
 /dataSources.local.xml
 /misc.xml
+/libraries/

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -76,7 +76,7 @@ def main(log: Logger, args: argparse.Namespace):
         accumulator.add(check.send_report(run_result))
         accumulator.add(slack_channel.send_report(run_result))
         if slack_personal:
-            accumulator.add(slack_personal.send_report(run_result))
+            slack_personal.send_report(run_result)
         accumulator.add(jira.send_report(run_result))
         accumulator.add(github_comment.send_report(run_result))
         if accumulator.failures:

--- a/run_properties.yml
+++ b/run_properties.yml
@@ -16,3 +16,13 @@ build:
   console:
     logLevel: INFO
     width: 160
+stages:
+  - name: 'build'
+    icon: '🏗️'
+  - name: 'test'
+    icon: '📋'
+  - name : 'deploy'
+    icon: '🚀'
+  - name: 'postdeploy'
+    icon: '🦺️'
+

--- a/src/mpyl/cli/commands/build/mpyl.py
+++ b/src/mpyl/cli/commands/build/mpyl.py
@@ -70,7 +70,6 @@ def run_mpyl(mpyl_run_parameters: MpylRunParameters, reporter: Optional[Reporter
     console_properties = mpyl_run_parameters.run_config.run_properties.console
     console = Console(markup=False, width=None if params.local else console_properties.width, no_color=False,
                       log_path=False, color_system='256')
-    print(f"Logging properties: {console_properties}, console: {console}")
     logging.raiseExceptions = False
     logging.basicConfig(
         level="DEBUG" if params.verbose else console_properties.log_level, format=FORMAT, datefmt="[%X]",

--- a/src/mpyl/cli/commands/build/mpyl.py
+++ b/src/mpyl/cli/commands/build/mpyl.py
@@ -126,18 +126,22 @@ def find_build_set(repo: Repository, changes_in_branch: list[Revision], build_al
 
 
 def run_build(accumulator: RunResult, executor: Steps, reporter: Optional[Reporter] = None, dry_run: bool = True):
-    for stage, projects in accumulator.run_plan.items():
-        for proj in projects:
-            result = executor.execute(stage, proj, dry_run)
-            accumulator.append(result)
-            if reporter:
-                reporter.send_report(accumulator)
+    try:
+        for stage, projects in accumulator.run_plan.items():
+            for proj in projects:
+                result = executor.execute(stage, proj, dry_run)
+                accumulator.append(result)
+                if reporter:
+                    reporter.send_report(accumulator)
 
-            if not result.output.success and stage == Stage.DEPLOY:
-                logging.warning(f'Deployment failed for {proj.name}')
+                if not result.output.success and stage == Stage.DEPLOY:
+                    logging.warning(f'Deployment failed for {proj.name}')
+                    return accumulator
+
+            if accumulator.failed_result:
+                logging.warning(f'One of the builds failed at {stage}')
                 return accumulator
-
-        if accumulator.failed_result:
-            logging.warning(f'One of the builds failed at {stage}')
-            return accumulator
-    return accumulator
+        return accumulator
+    except ExecutionException as exc:
+        accumulator.exception = exc
+        return accumulator

--- a/src/mpyl/cli/commands/health/checks.py
+++ b/src/mpyl/cli/commands/health/checks.py
@@ -35,6 +35,8 @@ class HealthConsole:
 
 def perform_health_checks(bare_console: Console):
     console = HealthConsole(bare_console)
+    load_dotenv(Path(".env"))
+
     console.title('Version')
     __check_version(console)
 
@@ -107,9 +109,9 @@ def __check_version(console):
 
 
 def __check_config(console, env_var, default, schema_path, name):
-    path = os.environ.get(env_var, default=default)
-    location = f"{name} at `/{path}` via environment variable `{env_var}`" if os.environ.get(
-        env_var) else f"{name} at `/{path}`"
+    path_env = os.environ.get(env_var)
+    path = path_env or default
+    location = f"{name} at `/{path}` via environment variable `{env_var}`" if path_env else f"{name} at `/{path}`"
     if os.path.exists(path):
         console.check(f"Found {location}", success=True)
 

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -76,7 +76,6 @@ class PullRequestReporter(Reporter):
         self.git_repository = Repository(RepoConfig.from_config(config))
         self.compose_function = compose_function
         self.update_strategy: GithubUpdateStategy = update_stategy
-
         self.body_separator = "----"
 
     def _get_pull_request(self, repo: GithubRepository, run_properties: RunProperties) -> Optional[PullRequest]:
@@ -95,7 +94,7 @@ class PullRequestReporter(Reporter):
 
     def _extract_pr_header(self, current_body: Optional[str]) -> str:
         body_header = current_body.split(self.body_separator)[0] if current_body else ""
-        return body_header.rstrip("\n") + f"\n{self.body_separator}\n"
+        return body_header.rstrip("\n") + f"\n\n{self.body_separator}\n"
 
     def _change_pr_body(self, pull_request: PullRequest, results: RunResult):
         pull_request.edit(

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -143,7 +143,7 @@ def to_markdown_summary(ticket: JiraTicket, run_result: RunResult) -> str:
 
     build_status = f"🏗️ Build [{details.build_id}]({details.run_url}) {run_result.status_line}, " \
                    f"started by _{details.user}_  \n{markdown_for_stage(run_result, Stage.DEPLOY)}"
-    return f"📕 [{ticket.ticket_id}]({ticket.ticket_url}) {ticket.summary} " \
+    return f"### 📕 [{ticket.ticket_id}]({ticket.ticket_url}) {ticket.summary} " \
            f'<img src="{ticket.user_avatar}" width="24" height="24" alt="{ticket.user_email}" /> \n' \
            f"{description_markdown}\n\n" \
            f"{build_status}"

--- a/src/mpyl/reporting/targets/slack.py
+++ b/src/mpyl/reporting/targets/slack.py
@@ -107,13 +107,15 @@ class SlackReporter(Reporter):
 
     def send_report(self, results: RunResult, text: Optional[str] = None) -> ReportOutcome:
         try:
-            user_info = self.__get_user_info(results.run_properties.details.user_email)
+            email = results.run_properties.details.user_email
+            user_info = self.__get_user_info(email)
 
             if not self._channel and user_info.initiator:
                 self._channel = self.__open_conversation_with_user(user_info.initiator)
 
             if not self._channel:
-                raise ValueError('Channel not explicitly set and initiator could not be determined')
+                return SlackOutcome(success=False, exception=ValueError(
+                    f'Channel not explicitly set and initiator for {email} could not be determined'))
 
             body = to_slack_markdown(text if text else run_result_to_markdown(results))
             blocks = self.__compose_blocks(results, body, user_info)

--- a/src/mpyl/schema/run_properties.schema.yml
+++ b/src/mpyl/schema/run_properties.schema.yml
@@ -51,17 +51,11 @@ properties:
         description: defines the run properties
         type: object
         additionalProperties: false
-        required:
-          - deploy_target
         properties:
           deploy_target:
             description: The deploy target.
-            type: string
-            enum:
-              - 'PullRequest'
-              - 'PullRequestBase'
-              - 'Acceptance'
-              - 'Production'
+            type: ["string", "null"]
+            enum: [ null,  'PullRequest', 'PullRequestBase', 'Production' ]
       console:
         type: object
         additionalProperties: false

--- a/src/mpyl/schema/run_properties.schema.yml
+++ b/src/mpyl/schema/run_properties.schema.yml
@@ -93,3 +93,14 @@ properties:
           tag:
             description: reference that points to the MPyL version
             type: ["string", "null"]
+  stages:
+    description: defines stages in a run
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        icon:
+          type: string

--- a/src/mpyl/stages/discovery.py
+++ b/src/mpyl/stages/discovery.py
@@ -53,7 +53,7 @@ def _to_relevant_changes(project: Project, stage: Stage, change_history: list[Re
     return relevant
 
 
-def are_invalidated(project: Project, stage: Stage, change_history: list[Revision]) -> bool:
+def _are_invalidated(project: Project, stage: Stage, change_history: list[Revision]) -> bool:
     if project.stages.for_stage(stage) is None:
         return False
 
@@ -63,7 +63,7 @@ def are_invalidated(project: Project, stage: Stage, change_history: list[Revisio
 
 def find_invalidated_projects_for_stage(all_projects: set[Project], stage: Stage,
                                         change_history: list[Revision]) -> set[Project]:
-    return set(filter(lambda p: are_invalidated(p, stage, change_history), all_projects))
+    return set(filter(lambda p: _are_invalidated(p, stage, change_history), all_projects))
 
 
 def find_deploy_set(repo_config: RepoConfig, tag: Optional[str]) -> DeploySet:

--- a/src/mpyl/steps/__init__.py
+++ b/src/mpyl/steps/__init__.py
@@ -70,12 +70,12 @@ from ..project import Stage
 
 
 class IPluginRegistry(type):
-    plugin_registries: List[type] = []
+    plugins: List[type] = []
 
     def __init__(cls, name, _bases, _attrs):
         super().__init__(cls)
         if name != 'Step':
-            IPluginRegistry.plugin_registries.append(cls)
+            IPluginRegistry.plugins.append(cls)
 
 
 @dataclass(frozen=True)

--- a/src/mpyl/steps/__init__.py
+++ b/src/mpyl/steps/__init__.py
@@ -58,6 +58,10 @@ example `mpyl.utilities.docker.DockerConfig`, this can be constructed from the `
 dictionary on `mpyl.steps.models.Input.run_properties`.
 Make sure to update the schema under `src/mpyl/schema/mpyl_config.schema.yml` accordingly, so that the configuration
 remains type safe and mistakes are found as early as possible.
+
+##### Registration with the executor
+Importing the module in which your step is defined is enough to register it.
+Steps are automatically registered with the `mpyl.steps.steps.Steps` executor via the `IPluginRegistry` metaclass.
 """
 from __future__ import annotations
 

--- a/src/mpyl/steps/build/echo.py
+++ b/src/mpyl/steps/build/echo.py
@@ -3,8 +3,9 @@
 from logging import Logger
 
 from .. import Step, Meta
-from ..models import Input, Output, ArtifactType
+from ..models import Input, Output, ArtifactType, input_to_artifact
 from ...project import Stage
+from ...utilities.docker import docker_image_tag
 
 
 class BuildEcho(Step):
@@ -19,4 +20,6 @@ class BuildEcho(Step):
 
     def execute(self, step_input: Input) -> Output:
         self._logger.info(f"Building project {step_input.project.name}")
-        return Output(success=True, message=f"Built {step_input.project.name}", produced_artifact=None)
+        artifact = input_to_artifact(ArtifactType.DOCKER_IMAGE, step_input,
+                                     spec={'image': docker_image_tag(step_input)})
+        return Output(success=True, message=f"Built {step_input.project.name}", produced_artifact=artifact)

--- a/src/mpyl/steps/collection.py
+++ b/src/mpyl/steps/collection.py
@@ -13,8 +13,7 @@ class StepsCollection:
 
     def __init__(self, logger: Logger, base_path: Optional[str] = None) -> None:
         self._step_executors = set()
-        self._base_path = base_path
-        self.__load_steps_in_module('.')
+        self.__load_steps_in_module('.', base_path)
 
         for plugin in IPluginRegistry.plugins:
             step_instance: Step = plugin(logger)
@@ -22,8 +21,9 @@ class StepsCollection:
             logger.debug(f"{meta.name} for stage {meta.stage} registered. Description: {meta.description}")
             self._step_executors.add(step_instance)
 
-    def __load_steps_in_module(self, module_root: str):
-        module = importlib.import_module(module_root, f'{self._base_path + "." if self._base_path else ""}mpyl.steps')
+    @staticmethod
+    def __load_steps_in_module(module_root: str, base_path: Optional[str] = None):
+        module = importlib.import_module(module_root, f'{base_path + "." if base_path else ""}mpyl.steps')
         for _, modname, _ in pkgutil.walk_packages(path=module.__path__, prefix=module.__name__ + '.',
                                                    onerror=lambda x: None):
             importlib.import_module(modname)

--- a/src/mpyl/steps/collection.py
+++ b/src/mpyl/steps/collection.py
@@ -1,0 +1,44 @@
+"""A collection of all available step executors."""
+from logging import Logger
+from typing import Optional
+
+from . import Step
+from .build.dockerbuild import BuildDocker
+from .build.echo import BuildEcho
+from .build.sbt import BuildSbt
+from .deploy.cloudfront_kubernetes_deploy import CloudFrontKubernetesDeploy
+from .deploy.echo import DeployEcho
+from .deploy.ephemeral_docker_deploy import EphemeralDockerDeploy
+from .deploy.kubernetes import DeployKubernetes
+from .deploy.kubernetes_job import DeployKubernetesJob
+from .deploy.kubernetes_spark_job import DeployKubernetesSparkJob
+from .postdeploy.cypress_test import CypressTest
+from .test.dockertest import TestDocker
+from .test.echo import TestEcho
+from .test.sbt import TestSbt
+from ..project import Stage
+
+
+class StepsCollection:
+    _step_executors: set[Step]
+
+    def __init__(self, logger: Logger) -> None:
+        self._step_executors = {
+            BuildEcho(logger),
+            BuildSbt(logger),
+            BuildDocker(logger),
+            TestEcho(logger),
+            TestSbt(logger),
+            TestDocker(logger),
+            CloudFrontKubernetesDeploy(logger),
+            DeployEcho(logger),
+            DeployKubernetes(logger),
+            DeployKubernetesJob(logger),
+            DeployKubernetesSparkJob(logger),
+            EphemeralDockerDeploy(logger),
+            CypressTest(logger)
+        }
+
+    def get_executor(self, stage: Stage, step_name: str) -> Optional[Step]:
+        executors = filter(lambda e: step_name == e.meta.name and e.meta.stage == stage, self._step_executors)
+        return next(executors, None)

--- a/src/mpyl/steps/collection.py
+++ b/src/mpyl/steps/collection.py
@@ -1,43 +1,32 @@
 """A collection of all available step executors."""
+import importlib
+import pkgutil
 from logging import Logger
 from typing import Optional
 
-from . import Step
-from .build.dockerbuild import BuildDocker
-from .build.echo import BuildEcho
-from .build.sbt import BuildSbt
-from .deploy.cloudfront_kubernetes_deploy import CloudFrontKubernetesDeploy
-from .deploy.echo import DeployEcho
-from .deploy.ephemeral_docker_deploy import EphemeralDockerDeploy
-from .deploy.kubernetes import DeployKubernetes
-from .deploy.kubernetes_job import DeployKubernetesJob
-from .deploy.kubernetes_spark_job import DeployKubernetesSparkJob
-from .postdeploy.cypress_test import CypressTest
-from .test.dockertest import TestDocker
-from .test.echo import TestEcho
-from .test.sbt import TestSbt
+from . import Step, IPluginRegistry
 from ..project import Stage
 
 
 class StepsCollection:
     _step_executors: set[Step]
 
-    def __init__(self, logger: Logger) -> None:
-        self._step_executors = {
-            BuildEcho(logger),
-            BuildSbt(logger),
-            BuildDocker(logger),
-            TestEcho(logger),
-            TestSbt(logger),
-            TestDocker(logger),
-            CloudFrontKubernetesDeploy(logger),
-            DeployEcho(logger),
-            DeployKubernetes(logger),
-            DeployKubernetesJob(logger),
-            DeployKubernetesSparkJob(logger),
-            EphemeralDockerDeploy(logger),
-            CypressTest(logger)
-        }
+    def __init__(self, logger: Logger, base_path: Optional[str] = None) -> None:
+        self._step_executors = set()
+        self._base_path = base_path
+        self.__load_steps_in_module('.')
+
+        for plugin in IPluginRegistry.plugins:
+            step_instance: Step = plugin(logger)
+            meta = step_instance.meta
+            logger.debug(f"{meta.name} for stage {meta.stage} registered. Description: {meta.description}")
+            self._step_executors.add(step_instance)
+
+    def __load_steps_in_module(self, module_root: str):
+        module = importlib.import_module(module_root, f'{self._base_path + "." if self._base_path else ""}mpyl.steps')
+        for _, modname, _ in pkgutil.walk_packages(path=module.__path__, prefix=module.__name__ + '.',
+                                                   onerror=lambda x: None):
+            importlib.import_module(modname)
 
     def get_executor(self, stage: Stage, step_name: str) -> Optional[Step]:
         executors = filter(lambda e: step_name == e.meta.name and e.meta.stage == stage, self._step_executors)

--- a/src/mpyl/steps/models.py
+++ b/src/mpyl/steps/models.py
@@ -107,7 +107,7 @@ class RunProperties:
 
         return RunProperties(
             details=RunContext.from_configuration(build['run']),
-            target=Target(build['parameters']['deploy_target'] or Target.PULL_REQUEST.value),
+            target=Target(build['parameters'].get('deploy_target', None) or Target.PULL_REQUEST.value),
             versioning=versioning,
             config=config,
             console=console,

--- a/src/mpyl/steps/models.py
+++ b/src/mpyl/steps/models.py
@@ -107,7 +107,7 @@ class RunProperties:
 
         return RunProperties(
             details=RunContext.from_configuration(build['run']),
-            target=Target(build['parameters']['deploy_target']),
+            target=Target(build['parameters']['deploy_target'] or Target.PULL_REQUEST.value),
             versioning=versioning,
             config=config,
             console=console,

--- a/src/mpyl/steps/steps.py
+++ b/src/mpyl/steps/steps.py
@@ -38,9 +38,6 @@ class StepResult:
     timestamp: datetime = datetime.now()
 
 
-
-
-
 class Steps:
     """ Executor of individual steps within a pipeline. """
     _logger: Logger

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -122,6 +122,9 @@ class Repository:
 
     def changes_in_branch(self) -> list[Revision]:
         revisions = list(reversed(list(self._repo.iter_commits(f"{self._config.main_branch}..HEAD"))))
+        if not revisions:
+            return []
+
         files_touched_in_branch = set(
             self._repo.git.diff(f'{revisions[0].hexsha}..{revisions[-1].hexsha}', name_only=True).splitlines())
         return [self.__to_revision(count, rev, files_touched_in_branch) for count, rev in enumerate(revisions)]

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -70,6 +70,8 @@ class Repository:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._repo.close()
+        if exc_val:
+            raise exc_val
         return self
 
     @property

--- a/tests/cli/commands/test_build.py
+++ b/tests/cli/commands/test_build.py
@@ -1,0 +1,70 @@
+import logging
+
+from src.mpyl.cli.commands.build.mpyl import run_build
+from src.mpyl.project import Stage
+from src.mpyl.steps import Step, Meta, ArtifactType, Input, Output
+from src.mpyl.steps.run import RunResult
+from src.mpyl.steps.steps import Steps, StepsCollection
+from tests.test_resources.test_data import get_minimal_project, RUN_PROPERTIES, get_project_with_stages
+
+
+class ThrowingStep(Step):
+    def __init__(self, logger: logging.Logger) -> None:
+        super().__init__(logger, Meta(
+            name='Throwing Build',
+            description='Throwing build step to validate error handling',
+            version='0.0.1',
+            stage=Stage.BUILD,
+        ), produced_artifact=ArtifactType.NONE, required_artifact=ArtifactType.NONE)
+
+    def execute(self, step_input: Input) -> Output:
+        raise Exception("this is not good")
+
+
+class TestBuildCommand:
+
+    def test_run_build_without_plan_should_be_successful(self):
+        run_properties = RUN_PROPERTIES
+        accumulator = RunResult(run_properties=run_properties)
+        executor = Steps(logging.getLogger(), run_properties, StepsCollection(logging.getLogger(), "src"))
+        result = run_build(accumulator, executor, None)
+        assert not result.has_results
+        assert result.is_success
+        assert result.status_line == '🦥 Nothing to do'
+
+    def test_run_build_with_plan_should_execute_successfully(self):
+        run_properties = RUN_PROPERTIES
+
+        projects = [get_minimal_project()]
+        run_plan = {
+            Stage.BUILD: projects,
+            Stage.TEST: projects,
+            Stage.DEPLOY: projects
+        }
+        accumulator = RunResult(run_properties=run_properties, run_plan=run_plan)
+        executor = Steps(logging.getLogger(), run_properties, StepsCollection(logging.getLogger(), "src"))
+        result = run_build(accumulator, executor, None)
+        assert result.exception is None
+        assert result.status_line == '✅ Successful'
+        assert result.is_success
+
+        assert result.exception is None
+
+    def test_run_build_throwing_step_should_be_handled(self):
+        run_properties = RUN_PROPERTIES
+
+        projects = [get_project_with_stages({'build': 'Throwing Build'})]
+        run_plan = {Stage.BUILD: projects}
+        accumulator = RunResult(run_properties=run_properties, run_plan=run_plan)
+        logger = logging.getLogger()
+        collection = StepsCollection(logger, "src")
+        executor = Steps(logger, run_properties, collection)
+
+        result = run_build(accumulator, executor, None)
+        assert not result.has_results
+        assert result.status_line == '❗ Failed with exception'
+
+        assert result.exception.message == 'this is not good'
+        assert result.exception.stage == Stage.BUILD.name
+        assert result.exception.project_name == 'test'
+        assert result.exception.executor == 'Throwing Build'

--- a/tests/reporting/targets/test_github.py
+++ b/tests/reporting/targets/test_github.py
@@ -1,4 +1,4 @@
-from mpyl.reporting.targets.github import PullRequestReporter, GithubUpdateStategy
+from src.mpyl.reporting.targets.github import PullRequestReporter, GithubUpdateStategy
 from tests.test_resources.test_data import get_config_values
 
 
@@ -8,16 +8,18 @@ class TestGithubReporter:
     def test_replace_pr_body_empty(self):
         assert self.reporter._extract_pr_header(
             current_body=None
-        ) == f"\n{self.reporter.body_separator}\n"
+        ) == f"\n\n{self.reporter.body_separator}\n"
 
     def test_replace_pr_body(self):
         assert self.reporter._extract_pr_header(
             current_body="body"
-        ) == f"body\n{self.reporter.body_separator}\n"
+        ) == f"body\n\n{self.reporter.body_separator}\n"
 
     def test_replace_pr_body_repeated(self):
         assert self.reporter._extract_pr_header(
             current_body=self.reporter._extract_pr_header(
-                current_body="body"
+                current_body=self.reporter._extract_pr_header(
+                    current_body="body"
+                )
             )
-        ) == f"body\n{self.reporter.body_separator}\n"
+        ) == f"body\n\n{self.reporter.body_separator}\n"

--- a/tests/reporting/targets/test_reporters.py
+++ b/tests/reporting/targets/test_reporters.py
@@ -1,6 +1,6 @@
-from mpyl.reporting.targets import ReportAccumulator
-from mpyl.reporting.targets.github import GithubOutcome
-from mpyl.reporting.targets.slack import SlackOutcome
+from src.mpyl.reporting.targets import ReportAccumulator
+from src.mpyl.reporting.targets.github import GithubOutcome
+from src.mpyl.reporting.targets.slack import SlackOutcome
 
 
 class TestReporters:

--- a/tests/reporting/targets/test_resources/markdown_jira_ticket_to_github.md
+++ b/tests/reporting/targets/test_resources/markdown_jira_ticket_to_github.md
@@ -1,4 +1,4 @@
-📕 [TECH-290](https://vandebron.atlassian.net/browse/TECH-290) Update PR description in github with deployment info <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
+### 📕 [TECH-290](https://vandebron.atlassian.net/browse/TECH-290) Update PR description in github with deployment info <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
 Similarly to mpl **modules**, we *should* update the PR details with card description, links to swagger (if they have), links to deployment in cluster, etc.
 
 ###### Should support Jira markdown

--- a/tests/stages/test_discovery.py
+++ b/tests/stages/test_discovery.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from mpyl.constants import BUILD_ARTIFACTS_FOLDER
-from mpyl.steps import Output
+from src.mpyl.constants import BUILD_ARTIFACTS_FOLDER
+from src.mpyl.steps import Output
 from src.mpyl.project import Stage
 from src.mpyl.projects.find import load_projects
 from src.mpyl.stages.discovery import find_invalidated_projects_for_stage, output_invalidated

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -85,7 +85,7 @@ class TestSteps:
         result = self.executor.execute(stage=Stage.BUILD, project=project)
         assert result.output.success
         assert result.output.message == 'Built test'
-        assert result.output.produced_artifact is None
+        assert result.output.produced_artifact.artifact_type == ArtifactType.DOCKER_IMAGE
 
     def test_should_fail_if_executor_is_not_known(self):
         project = test_data.get_project_with_stages({'build': 'Unknown Build'})

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -7,6 +7,7 @@ from jsonschema import ValidationError
 from pyaml_env import parse_config
 from ruamel.yaml import YAML  # type: ignore
 
+from src.mpyl.steps.collection import StepsCollection
 from src.mpyl.constants import DEFAULT_CONFIG_FILE_NAME, BUILD_ARTIFACTS_FOLDER
 from src.mpyl.project import Project, Stages, Stage, Target, Dependencies
 from src.mpyl.steps.models import Output, ArtifactType, RunProperties, VersioningProperties, ConsoleProperties
@@ -20,7 +21,8 @@ yaml = YAML()
 
 class TestSteps:
     resource_path = root_test_path / "test_resources"
-    executor = Steps(logger=logging.getLogger(), properties=test_data.RUN_PROPERTIES)
+    executor = Steps(logger=logging.getLogger(), properties=test_data.RUN_PROPERTIES,
+                     steps_collection=StepsCollection(logging.getLogger(), "src"))
 
     docker_image = get_output()
     build_project = test_data.get_project_with_stages({'build': 'Echo Build'}, path=str(resource_path))

--- a/tests/test_resources/mpyl_config.yml
+++ b/tests/test_resources/mpyl_config.yml
@@ -72,7 +72,7 @@ s3:
   accessKeyId: !ENV ${AWS_ACCESS_KEY_ID:aws_access_key_id}
   secretAccessKey: !ENV ${AWS_SECRET_ACCESS_KEY:aws_secret_access_key}
 project: # default values
-  allowedMaintainers: [ 'Team1', 'Team2' ]
+  allowedMaintainers: [ 'Team1', 'Team2', 'MPyL' ]
   deployment:
     traefik:
       enabled: true

--- a/tests/test_resources/run_properties.yml
+++ b/tests/test_resources/run_properties.yml
@@ -6,7 +6,7 @@ build:
     tests_url: !ENV ${RUN_TESTS_DISPLAY_URL:http://localhost:3000/}
     user_email: !ENV ${BUILD_USER_EMAIL}
   parameters:
-    deploy_target: !ENV ${DEPLOY_TARGET:PullRequest}
+    deploy_target: !ENV ${DEPLOY_TARGET}
   versioning:
     revision: !ENV ${GIT_COMMIT:hash}
     branch: !ENV ${CHANGE_BRANCH}

--- a/tests/test_resources/test_minimal_project.yml
+++ b/tests/test_resources/test_minimal_project.yml
@@ -1,9 +1,9 @@
 name: 'minimalService'
 description: 'This is a test container. For testing the MPL pipelines, not to be deployed anywhere.'
 stages:
-  build: Docker Build
-  test: Docker Test
-  deploy: Kubernetes Deploy
+  build: Echo Build
+  test: Echo Test
+  deploy: Echo Deploy
 maintainer: [ 'MPyL' ]
 build:
   args:

--- a/tests/utilities/test_s3.py
+++ b/tests/utilities/test_s3.py
@@ -1,4 +1,4 @@
-from mpyl.utilities.s3 import S3Client
+from src.mpyl.utilities.s3 import S3Client
 
 
 class TestS3:


### PR DESCRIPTION
Replacing the Stage enum with a dynamic set of stages that can be configured via `mpyl_config` requires significant refactorings.
In order to limit the scope of the work, this PR concerns itself with preparational work and small bugfixes only. In particular:

 - [x] Rewrite the build github action so the different CI stages may be run in parallel
 - [x] Discover step executors via the plugin mechanism instead of requiring them to be hardcoded in order to make it easier to locally define custom steps
 - [x] Remove .egg and .tar.gz distribution formats because pypi no longer accepts them
 - [x] Create end-to-end build test, to have more confidence about the execution mechanism at unit test time
 - [x] Prevent exceptions thrown in the scope of a Repostirory try with resources from being swallowed
 - [x] Attempt to fix local builds via the `mpyl` CLI in the root.

Note: `.env` in the monorepo should not contain `MPYL_CONFIG_PATH=deployment/pipeline/mpyl/config.yml` in case it still does. Perhaps you could make sure that `mpyl build status` and `mpyl health` still work on the monorepo.

----
### 📕 [TECH-293](https://vandebron.atlassian.net/browse/TECH-293) As an MPyL user I want to define my own stage(s) <img src="https://secure.gravatar.com/avatar/22987b802af30079346039ff7c67e6fa?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FES-1.png" width="24" height="24" alt="ewaldschrader@vandebron.nl" /> 
At the moment stages are a hardcoded concept in MPyL [steps.py#L60-L85](https://github.com/Vandebron/mpyl/blob/37c7b0c9a7e9eb54dfb05d8822c4e360469855b7/src/mpyl/steps/steps.py#L60-L85) 

While there is potential order dependency between build steps, a fixed order is too limiting. For example, a *security scan_ or _integration test* stage could be run in parallel after the build stage. Defining the execution flow is more at home in the (python) definition of the flow than within the library.

An important aspect to consider is the invalidation logic, which is stage specific (at the moment) [discovery.py#L41-L43](https://github.com/Vandebron/mpyl/blob/e0a8fabcf5c08492f0382bae4df8d5502b45d155/src/mpyl/stages/discovery.py#L41-L43). Perhaps this could be converted to a strategy.

🏗️ Build [13](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-149/13/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-149.test.nl/)*, *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-149.test.nl/)*, *[sbtservice](https://sbtservice-149.test.nl/)*  


[TECH-293]: https://vandebron.atlassian.net/browse/TECH-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ