### PR TITLE
[TECH-457] Fix subprocess reporting

### DIFF
--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -36,9 +36,10 @@ def custom_check_output(logger: Logger, command: Union[str, list[str]], capture_
                     break
             success = process.wait() == 0
             if not success:
-                logger.warning(f"Subprocess failed: {process.stderr.read() if process.stderr else 'No stderr output'}")
+                logger.warning('Subprocess failed' + f' with {process.stderr.read()}' if process.stderr else "")
+                return Output(success=False, message='Subprocess failed')
 
-            return Output(success=success, message='Subprocess executed successfully')
+            return Output(success=True, message='Subprocess executed successfully')
 
 
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
branch: feature/TECH-457_fix_subprocess_result
----
📕 [TECH-457](https://vandebron.atlassian.net/browse/TECH-457) Fix master pipeline <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Seems like we broke the master pipeline again

Master pipeline should build all projects and not fail fast → this part should be fixed with [142](https://github.com/Vandebron/mpyl/pull/142) 

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-154/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-154.test.nl/)*, *enrichChargeSessionsJob*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-154.test.nl/)*, *[sbtservice](https://sbtservice-154.test.nl/)*  


[TECH-457]: https://vandebron.atlassian.net/browse/TECH-457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ