### PR TITLE
[TECH-480] Remove the checkout scm step from the mpyl jenkinsfile to …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,11 +21,6 @@ pipeline {
                 }
             }
         }
-        stage('Checkout') {
-            steps {
-                checkout scm
-            }
-        }
         stage('Build') {
            environment {
                 DOCKER_REGISTRY = credentials('91751de6-20aa-4b12-8459-6e16094a233a')


### PR DESCRIPTION
…improve performance

branch: feature/TECH-480-improve-mpyl-installation

----
### 📕 [TECH-480](https://vandebron.atlassian.net/browse/TECH-480) Improve mpyl installation <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Our installation logic in the jenkinsfile’s still doesn’t work entirely as it should. If you pass no version it installs the latest version from test.pypi instead of 1.0.6 (our latest released version at the moment this ticket gets created). We think it might be due to the '`--site-packages`' tag.

We also think people should always specify which version they want to run. So the easy fix is just to remove the option to leave the version empty, this will ensure the install cmd always has/passes a version (the default is the hardcoded value in the jenkinsfile) and the tag won’t be needed anymore hopefully.

🏗️ Build [6](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-160/6/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-160.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-160.test.nl/)*, *[sbtservice](https://sbtservice-160.test.nl/)*, *sparkJob*  


[TECH-480]: https://vandebron.atlassian.net/browse/TECH-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ