### PR TITLE
[TECH-440] Implement a new way to get changes in branch that ignores …

### DIFF
--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -135,11 +135,12 @@ class Repository:
         return Revision(count, str(revision), intersection)
 
     def changes_in_branch(self) -> list[Revision]:
+        self.pull_main_branch()
         revisions = list(
             reversed(
                 list(
                     self._repo.iter_commits(
-                        f"origin/{self._config.main_branch}..HEAD", no_merges=True
+                        f"{self._config.main_branch}..HEAD", no_merges=True
                     )
                 )
             )

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -2,13 +2,13 @@
 `mpyl.utilities.repo.Repository` is a facade for the Version Control System.
 At this moment Git is the only supported VCS.
 """
-
+import itertools
 import logging
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 from urllib.parse import urlparse
-
 from git import Git, Repo, Remote
 from git.objects import Commit
 
@@ -152,13 +152,16 @@ class Repository:
         if not revisions:
             return []
 
-        changed_files = []
-        for rev in revisions:
-            changed_files.extend(
-                self._repo.git.diff_tree(
-                    rev, name_only=True, no_commit_id=True, r=True
-                ).splitlines(),
+        changed_files = list(
+            itertools.chain.from_iterable(
+                [
+                    self._repo.git.diff_tree(
+                        rev, name_only=True, no_commit_id=True, r=True
+                    ).splitlines()
+                    for rev in revisions
+                ]
             )
+        )
 
         return [
             self.__to_revision(count, rev, set(changed_files))


### PR DESCRIPTION
…merge commits

branch: feature/TECH-440-ignore-merge-commits

----
### 📕 [TECH-440](https://vandebron.atlassian.net/browse/TECH-440) Ignore merge commits in build plan <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Currently your build plan gets messed up if you’ve done a merge instead of a rebase, it will recognize all changes of the merge. It would be nice if we could ignore merge commits somehow while determining the build plan.

🏗️ Build [6](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-166/6/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-166.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-166.test.nl/)*, *[sbtservice](https://sbtservice-166.test.nl/)*, *sparkJob*  


[TECH-440]: https://vandebron.atlassian.net/browse/TECH-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ