### PR TITLE
feature/TECH 488 namespace logic

### DIFF
--- a/src/mpyl/cli/commands/health/checks.py
+++ b/src/mpyl/cli/commands/health/checks.py
@@ -33,7 +33,7 @@ class HealthConsole:
         self.console.print(Markdown(f"&nbsp;&nbsp;{icon} {check}"))
 
 
-def perform_health_checks(bare_console: Console):
+def perform_health_checks(bare_console: Console, is_ci: bool = False):
     console = HealthConsole(bare_console)
     load_dotenv(Path(".env"))
 
@@ -58,8 +58,9 @@ def perform_health_checks(bare_console: Console):
         name="run properties",
     )
 
-    console.title("Jenkins")
-    __check_jenkins(console)
+    if not is_ci:
+        console.title("Jenkins")
+        __check_jenkins(console)
 
 
 def __check_jenkins(console: HealthConsole):

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Optional
+
+import click
+import jsonschema
+from rich.console import Console
+
+from ....utilities.repo import Repository
+from ....cli.commands.build.mpyl import find_build_set
+from ....project import Project, load_project
+
+
+def _find_projects(all_, repo: Repository, filter_: str):
+    project_paths = []
+    if all_:
+        project_paths = repo.find_projects(filter_)
+    else:
+        branch = repo.get_branch
+        changes = (
+            repo.changes_in_branch_including_local()
+            if branch
+            else repo.changes_in_merge_commit()
+        )
+        build_set = find_build_set(repo, changes, False)
+        for all_projects in build_set.values():
+            for project in all_projects:
+                project_paths.append(project.path)
+    return project_paths
+
+
+def __load_project(
+    console: Optional[Console], root_dir: Path, project_path: str, verbose: bool = False
+) -> Optional[Project]:
+    try:
+        project = load_project(root_dir, Path(project_path), strict=True)
+    except jsonschema.exceptions.ValidationError as exc:
+        if console:
+            console.print(f"❌ {project_path}: {exc.message}")
+        return None
+    except Exception as exc:  # pylint: disable=broad-except
+        if console:
+            console.print(f"❌ {project_path}: {exc}")
+        return None
+    else:
+        if console and verbose:
+            console.print(f"✅ {project_path}")
+        return project
+
+
+def _check_and_load_projects(
+    console: Console, repo: Repository, project_paths: list[str]
+) -> list[Project]:
+    projects = [
+        __load_project(console, repo.root_dir(), project_path)
+        for project_path in set(project_paths)
+    ]
+    valid = len([project for project in projects if project])
+    invalid = len(projects) - valid
+    console.print(
+        f"Validated {valid + invalid} projects. {valid} valid, {invalid} invalid"
+    )
+    if invalid > 0:
+        click.get_current_context().exit(1)
+    return projects
+
+
+def _assert_unique_project_names(
+    console: Console, repo: Repository, projects: list[Project]
+):
+    current_project_names: set[str] = {project.name for project in projects}
+    remaining_project_names: set[str] = {
+        __load_project(None, repo.root_dir(), project_path).name
+        for project_path in repo.find_projects()
+    }.difference(current_project_names)
+    duplicates = current_project_names.intersection(remaining_project_names)
+    if duplicates:
+        console.print(
+            f"❌ Found {len(duplicates)} duplicate project names: {duplicates}"
+        )
+        click.get_current_context().exit(1)
+    console.print(f"✅ No duplicate project names found")

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -117,12 +117,17 @@ def _assert_correct_project_linkup(
     if len(wrong_substitutions_per_project.keys()) == 0:
         console.print("✅ No wrong namespace substitutions found")
     else:
+        all_project_names: dict[str, str] = {
+            project.name.lower(): project.name for project in all_projects
+        }
         for project_name, wrong_subsitutions in wrong_substitutions_per_project.items():
             console.print(
                 f"❌ Project {project_name} has wrong namespace substitutions:"
             )
             for env, url in wrong_subsitutions:
                 unrecognized_project_name = url.split(".{namespace}")[0].split("/")[-1]
+                suggestion = all_project_names.get(unrecognized_project_name.lower())
                 console.print(
                     f"  {env} references unrecognized project {unrecognized_project_name}"
+                    + (f" (did you mean {suggestion}?)" if suggestion else "")
                 )

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -11,11 +11,11 @@ from ....steps.deploy.k8s import substitute_namespaces
 from ....steps.deploy.k8s.chart import ChartBuilder
 from ....utilities.repo import Repository
 from ....cli.commands.build.mpyl import find_build_set
-from ....project import Project, load_project, ProjectName, Target
+from ....project import Project, load_project, Target
 
 
 def _find_project_paths(all_: bool, repo: Repository, filter_: str):
-    project_paths = []
+    project_paths: list[str] = []
     if all_:
         project_paths = repo.find_projects(filter_)
     else:
@@ -106,11 +106,6 @@ def _assert_correct_project_linkup(
         __detail_wrong_substitutions(console, all_projects, wrong_substitutions)
 
 
-def __get_project_name(project: Project) -> ProjectName:
-    namespace = project.deployment.namespace if project.deployment else None
-    return ProjectName(project.name, namespace)
-
-
 def __get_wrong_substitutions_per_project(
     all_projects: list[Project],
     projects: list[Project],
@@ -125,8 +120,8 @@ def __get_wrong_substitutions_per_project(
             )
             substituted: dict[str, str] = substitute_namespaces(
                 env_vars=env,
-                all_projects=set(map(__get_project_name, all_projects)),
-                projects_to_deploy=set(map(__get_project_name, projects)),
+                all_projects=set(map(lambda p: p.to_name, all_projects)),
+                projects_to_deploy=set(map(lambda p: p.to_name, projects)),
                 pr_identifier=pr_identifier,
             )
             wrong_subs = list(

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -5,12 +5,14 @@ import click
 import jsonschema
 from rich.console import Console
 
+from ....steps.deploy.k8s import substitute_namespaces
+from ....steps.deploy.k8s.chart import ChartBuilder
 from ....utilities.repo import Repository
 from ....cli.commands.build.mpyl import find_build_set
-from ....project import Project, load_project
+from ....project import Project, load_project, ProjectName, Target
 
 
-def _find_projects(all_, repo: Repository, filter_: str):
+def _find_projects(all_: bool, repo: Repository, filter_: str):
     project_paths = []
     if all_:
         project_paths = repo.find_projects(filter_)
@@ -29,10 +31,14 @@ def _find_projects(all_, repo: Repository, filter_: str):
 
 
 def __load_project(
-    console: Optional[Console], root_dir: Path, project_path: str, verbose: bool = False
+    console: Optional[Console],
+    root_dir: Path,
+    project_path: str,
+    verbose: bool = False,
+    strict: bool = True,
 ) -> Optional[Project]:
     try:
-        project = load_project(root_dir, Path(project_path), strict=True)
+        project = load_project(root_dir, Path(project_path), strict)
     except jsonschema.exceptions.ValidationError as exc:
         if console:
             console.print(f"❌ {project_path}: {exc.message}")
@@ -48,29 +54,29 @@ def __load_project(
 
 
 def _check_and_load_projects(
-    console: Console, repo: Repository, project_paths: list[str]
+    console: Optional[Console], repo: Repository, project_paths: list[str], strict: bool
 ) -> list[Project]:
     projects = [
-        __load_project(console, repo.root_dir(), project_path)
+        __load_project(console, repo.root_dir(), project_path, strict)
         for project_path in set(project_paths)
     ]
     valid = len([project for project in projects if project])
     invalid = len(projects) - valid
-    console.print(
-        f"Validated {valid + invalid} projects. {valid} valid, {invalid} invalid"
-    )
+    if console:
+        console.print(
+            f"Validated {valid + invalid} projects. {valid} valid, {invalid} invalid"
+        )
     if invalid > 0:
         click.get_current_context().exit(1)
     return projects
 
 
 def _assert_unique_project_names(
-    console: Console, repo: Repository, projects: list[Project]
+    console: Console, projects: list[Project], all_projects: list[Project]
 ):
     current_project_names: set[str] = {project.name for project in projects}
     remaining_project_names: set[str] = {
-        __load_project(None, repo.root_dir(), project_path).name
-        for project_path in repo.find_projects()
+        project.name for project in set(all_projects)
     }.difference(current_project_names)
     duplicates = current_project_names.intersection(remaining_project_names)
     if duplicates:
@@ -79,3 +85,38 @@ def _assert_unique_project_names(
         )
         click.get_current_context().exit(1)
     console.print(f"✅ No duplicate project names found")
+
+
+def __get_project_name(project: Project) -> ProjectName:
+    namespace = project.deployment.namespace if project.deployment else None
+    return ProjectName(project.name, namespace)
+
+
+def _assert_correct_project_linkup(
+    console: Console,
+    target: Target,
+    projects: list[Project],
+    all_projects: list[Project],
+    pr_identifier: Optional[str],
+):
+    project_names = set(map(__get_project_name, projects))
+    all_project_names = set(map(__get_project_name, all_projects))
+
+    for project in projects:
+        console.print(f"Checking namespace substitution for project {project.name}")
+        env_vars = ChartBuilder.extract_raw_env(
+            target=target, env=project.deployment.properties.env
+        )
+        substituted: dict[str, str] = substitute_namespaces(
+            env_vars=env_vars,
+            all_projects=all_project_names,
+            projects_to_deploy=project_names,
+            pr_identifier=pr_identifier,
+        )
+        wrong_subst = [k for k, v in substituted.items() if "{namespace}" in v]
+        if len(wrong_subst) == 0:
+            console.print(f"✅ No wrong namespace substitutions found")
+        else:
+            console.print(
+                f"❌ Found {len(wrong_subst)} wrong namespace substitutions: {wrong_subst}"
+            )

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -14,7 +14,7 @@ from ....cli.commands.build.mpyl import find_build_set
 from ....project import Project, load_project, ProjectName, Target
 
 
-def _find_projects(all_: bool, repo: Repository, filter_: str):
+def _find_project_paths(all_: bool, repo: Repository, filter_: str):
     project_paths = []
     if all_:
         project_paths = repo.find_projects(filter_)

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -114,7 +114,7 @@ def __get_wrong_substitutions_per_project(
 ) -> list[WrongLinkupPerProject]:
     project_linkup: list[WrongLinkupPerProject] = []
     for project in projects:
-        if project.deployment:
+        if project.deployment and project.deployment.properties:
             env = ChartBuilder.extract_raw_env(
                 target=target, env=project.deployment.properties.env
             )

--- a/src/mpyl/cli/health.py
+++ b/src/mpyl/cli/health.py
@@ -10,6 +10,7 @@ from .commands.health.checks import perform_health_checks
 @click.command("health")
 @click.option(
     "--ci",
+    "is_ci",
     is_flag=True,
     default=False,
     help="Run health checks relevant only for CI builds.",

--- a/src/mpyl/cli/health.py
+++ b/src/mpyl/cli/health.py
@@ -8,7 +8,13 @@ from .commands.health.checks import perform_health_checks
 
 
 @click.command("health")
-def health():
+@click.option(
+    "--ci",
+    is_flag=True,
+    default=False,
+    help="Run health checks relevant only for CI builds.",
+)
+def health(ci):
     """Health check"""
     console: Console = create_console_logger(local=False, verbose=False)
-    perform_health_checks(console)
+    perform_health_checks(console, ci)

--- a/src/mpyl/cli/health.py
+++ b/src/mpyl/cli/health.py
@@ -14,7 +14,7 @@ from .commands.health.checks import perform_health_checks
     default=False,
     help="Run health checks relevant only for CI builds.",
 )
-def health(ci):
+def health(is_ci):
     """Health check"""
     console: Console = create_console_logger(local=False, verbose=False)
-    perform_health_checks(console, ci)
+    perform_health_checks(console, is_ci)

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -126,17 +126,17 @@ def show_project(ctx, name):
 )
 @click.option(
     "--extended",
+    "-e",
     "extended",
     is_flag=True,
     help="Enable extra validations like PR namespace linkup",
 )
 @click.pass_obj
 def lint(obj: ProjectsContext, all_, extended):
-    project_paths = _find_projects(all_, obj.cli.repo, obj.filter)
     loaded_projects = _check_and_load_projects(
         console=obj.cli.console,
         repo=obj.cli.repo,
-        project_paths=project_paths,
+        project_paths=_find_projects(all_, obj.cli.repo, obj.filter),
         strict=True,
     )
     all_projects = _check_and_load_projects(

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -8,7 +8,7 @@ from click.shell_completion import CompletionItem
 from rich.markdown import Markdown
 
 from ..cli.commands.projects.lint import (
-    _find_projects,
+    _find_project_paths,
     _check_and_load_projects,
     _assert_unique_project_names,
     _assert_correct_project_linkup,
@@ -136,13 +136,13 @@ def lint(obj: ProjectsContext, all_, extended):
     loaded_projects = _check_and_load_projects(
         console=obj.cli.console,
         repo=obj.cli.repo,
-        project_paths=_find_projects(all_, obj.cli.repo, obj.filter),
+        project_paths=_find_project_paths(all_, obj.cli.repo, obj.filter),
         strict=True,
     )
     all_projects = _check_and_load_projects(
         console=None,
         repo=obj.cli.repo,
-        project_paths=_find_projects(True, obj.cli.repo, ""),
+        project_paths=_find_project_paths(True, obj.cli.repo, ""),
         strict=False,
     )
     _assert_unique_project_names(

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -147,7 +147,6 @@ def lint(obj: ProjectsContext, all_, extended):
     )
     _assert_unique_project_names(
         console=obj.cli.console,
-        projects=loaded_projects,
         all_projects=all_projects,
     )
     if not all_ and extended:

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -126,14 +126,13 @@ def show_project(ctx, name):
     help="Validate all project yaml's, regardless of changes on branch",
 )
 @click.option(
-    "--verbose",
-    "-v",
-    "verbose",
+    "--extended",
+    "extended",
     is_flag=True,
     help="Enable extra validations like PR namespace linkup",
 )
 @click.pass_obj
-def lint(obj: ProjectsContext, all_, verbose):
+def lint(obj: ProjectsContext, all_, extended):
     project_paths = _find_projects(all_, obj.cli.repo, obj.filter)
     loaded_projects = _check_and_load_projects(
         console=obj.cli.console,
@@ -152,7 +151,7 @@ def lint(obj: ProjectsContext, all_, verbose):
         projects=loaded_projects,
         all_projects=all_projects,
     )
-    if not all_ and verbose:
+    if not all_ and extended:
         _assert_correct_project_linkup(
             console=obj.cli.console,
             target=Target.PULL_REQUEST,

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -7,13 +7,12 @@ from click import ParamType, Argument
 from click.shell_completion import CompletionItem
 from rich.markdown import Markdown
 
-from mpyl.cli.commands.projects.lint import (
+from ..cli.commands.projects.lint import (
     _find_projects,
     _check_and_load_projects,
     _assert_unique_project_names,
     _assert_correct_project_linkup,
 )
-from mpyl.steps.models import RunProperties
 from . import (
     CliContext,
     CONFIG_PATH_HELP,
@@ -157,7 +156,7 @@ def lint(obj: ProjectsContext, all_, extended):
             target=Target.PULL_REQUEST,
             projects=loaded_projects,
             all_projects=all_projects,
-            pr_identifier="123",
+            pr_identifier=123,
         )
 
 

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -149,11 +149,11 @@ def lint(obj: ProjectsContext, all_, extended):
         console=obj.cli.console,
         all_projects=all_projects,
     )
-    if not all_ and extended:
+    if extended:
         _assert_correct_project_linkup(
             console=obj.cli.console,
             target=Target.PULL_REQUEST,
-            projects=loaded_projects,
+            projects=all_projects if all_ else loaded_projects,
             all_projects=all_projects,
             pr_identifier=123,
         )

--- a/src/mpyl/steps/deploy/k8s/__init__.py
+++ b/src/mpyl/steps/deploy/k8s/__init__.py
@@ -80,6 +80,29 @@ def substitute_namespaces(
     projects_to_deploy: set[ProjectName],
     pr_identifier: Optional[int],
 ) -> dict[str, str]:
+    """
+    Substitute namespaces in environment variables.
+
+    In the project yamls we define references to other projects with e.g.:
+
+    ```yaml
+    - key: SOME_SERVICE_URL:
+      all: http://serviceName.{namespace}.svc.cluster.local
+    ```
+
+    When the env var is substituted, first the referenced service (serviceName) is looked up in the list of projects.
+    If it is part of the deploy set, and we're in deploying to target PullRequest,
+    the namespace is subsituted with the PR namespace (pr-XXXX).
+    Else is substituted with the namespace of the referenced project.
+
+    Note that the name of the service in the env var is case-sensitive!
+
+    :param env_vars: environment variables to substitute
+    :param all_projects: all project in repo
+    :param projects_to_deploy: projects in deploy set
+    :param pr_identifier: PR number if applicable
+    :return: dictionary of substituted env vars
+    """
     env = env_vars.copy()
 
     def get_namespace_for_linked_project(project_name: ProjectName):

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -509,12 +509,15 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
     def _create_secret_env_vars(self, secret_list: list[KeyValueRef]) -> list[V1EnvVar]:
         return list(map(self._map_key_value_refs, secret_list))
 
-    def _get_env_vars(self):
+    @staticmethod
+    def extract_raw_env(target: Target, env: list[KeyValueProperty]):
         raw_env_vars = {
-            e.key: e.get_value(self.target)
-            for e in self.env
-            if e.get_value(self.target) is not None
+            e.key: e.get_value(target) for e in env if e.get_value(target) is not None
         }
+        return raw_env_vars
+
+    def _get_env_vars(self):
+        raw_env_vars = self.extract_raw_env(self.target, self.env)
         pr_identifier = (
             None
             if self.step_input.run_properties.versioning.tag


### PR DESCRIPTION
Monorepo counterpart: https://github.com/Vandebron/Vandebron/pull/11058

- Add ci flag for health check -> if we run build health in jenkins, it reported errors that jenkins is not configured correctly
- Check for duplicate project names when we run projects lint -> will fail the build if you try to merge a duplicate project name
- Validate namespace substitution for PR target when running `mpyl project lint --extended`

<img width="789" alt="Screenshot 2023-07-22 at 10 02 43" src="https://github.com/Vandebron/mpyl/assets/58272685/5e33ab33-f8dc-4f97-9209-10fb9259ef18">

----
### 📕 [TECH-488](https://vandebron.atlassian.net/browse/TECH-488) Validate namespace replacement logic <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Check namespace replacement

URLs should be interpolated with the name of the project

Add a command to `mpyl build health` to validate unique project names

* after loading all the projects, validating the yamls then check project names
* fail pipeline if project name is not unique
* check all project names in lower case -> give suggestions if there's a case-sensitity issue

create post about this logic + add it to mpyl documentation

🏗️ Build [7](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-167/7/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-167.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-167.test.nl/)*, *[sbtservice](https://sbtservice-167.test.nl/)*, *sparkJob*  


[TECH-488]: https://vandebron.atlassian.net/browse/TECH-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ