### PR TITLE
Add an actual pull to update the local main branch when needed

### DIFF
--- a/src/mpyl/cli/commands/build/mpyl.py
+++ b/src/mpyl/cli/commands/build/mpyl.py
@@ -62,7 +62,7 @@ def get_build_plan(
             )
         else:
             logger.info(f"Pulling `{repo.main_branch}` from {repo.get_remote_url}")
-            pull_result = repo.pull_main_branch()
+            pull_result = repo.fetch_main_branch()
             logger.info(f"Pulled `{pull_result[0].remote_ref_path.strip()}` to local")
         changes = (
             repo.changes_in_branch_including_local()

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -224,10 +224,15 @@ class Repository:
             self._config.repo_credentials.to_url_with_credentials
         )
 
-    def pull_main_branch(self):
+    def fetch_main_branch(self):
         remote = self.__get_remote()
         main = self._config.main_branch
         return remote.fetch(f"+refs/heads/{main}:refs/heads/{main}")
+
+    def pull_main_branch(self):
+        remote = self.__get_remote()
+        main = self._config.main_branch
+        return remote.pull(f"+refs/heads/{main}:refs/heads/{main}")
 
     def find_projects(self, folder_pattern: str = "") -> list[str]:
         """returns a set of all project.yml files


### PR DESCRIPTION
This is required since we are comparing to the local main branch in `changes_in_branch`. If you have rebased/merged the latest main branch into your pr but your local main branch is behind, it will detect those extra changes as changes of your branch. The previous 'pull' function gave an error when running mpyl locally on main because you're not supposed to fetch into your current branch (without `--update-head-ok`)

----
 # ⚠️ Could not find ticket corresponding to `feature/TECH-XXX-hotfix-mpyl. Does your branch name follow the correct pattern?