### PR TITLE
[TECH-493] Add a toggle for manual builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ pipeline {
                 script {
                     properties([parameters([
                         string(name: 'BUILD_PARAMS', defaultValue: '--all', description: 'Build parameters passed along with the run. Example: --help or --all'),
-                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository')
+                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository'),
+                        booleanParam(name: 'MANUAL_BUILD', defaultValue: false, description: 'Enable manual project selection later in the build'),
                     ])])
                     currentBuild.result = 'NOT_BUILT'
                     currentBuild.description = "Parameters can be set now"
@@ -43,6 +44,11 @@ pipeline {
                             sh "pipenv clean"
                             sh "pipenv install --ignore-pipfile --skip-lock --site-packages --index https://test.pypi.org/simple/ 'mpyl==$CHANGE_ID.*'"
                             sh "pipenv install -d --skip-lock"
+
+                            if (params.MANUAL_BUILD) {
+                                def projects = sh(script: "pipenv run mpyl projects list", returnStdout: true)
+                            }
+
                             sh "pipenv run mpyl projects lint --all"
                             sh "pipenv run mpyl health"
                             sh "pipenv run mpyl build status"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                             sh "pipenv install -d --skip-lock"
 
                             if (params.MANUAL_BUILD) {
-                                def projects = sh(script: "pipenv run mpyl projects list", returnStdout: true)
+                                def projects = sh(script: "pipenv run mpyl projects names", returnStdout: true)
                             }
 
                             sh "pipenv run mpyl projects lint --all"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,12 +47,18 @@ pipeline {
 
                             if (params.MANUAL_BUILD) {
                                 def projects = sh(script: "pipenv run mpyl projects names", returnStdout: true)
+                                def boolParams = projects.split('\n').collect { project ->
+                                    booleanParam(name: project, defaultValue: false)
+                                }
+                                def selectedProjects = input(id: 'userInput', message: 'Select project(s)', parameters: boolParams)
+                                def selectedProjectsString = selectedProjects.findAll { key, value -> value }.keySet().join(',')
+                                env.SELECTED_PROJECTS = "--projects " + selectedProjectsString
                             }
 
                             sh "pipenv run mpyl projects lint --all"
                             sh "pipenv run mpyl health"
                             sh "pipenv run mpyl build status"
-                            sh "pipenv run run-ci ${params.BUILD_PARAMS}"
+                            sh "pipenv run run-ci ${params.BUILD_PARAMS} ${env.SELECTED_PROJECTS}"
                         }
                     }
                 }

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -41,6 +41,7 @@ def main(log: Logger, args: argparse.Namespace):
             verbose=args.verbose,
             all=args.all,
             target=run_properties.target.value,
+            projects=args.projects,
         ),
     )
     check = None
@@ -114,6 +115,9 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument("--tag", "-t", help="The name of the tag to build", type=str)
+    parser.add_argument(
+        "--projects", "-p", help="Names of the projects to build", type=str
+    )
     parser.add_argument(
         "--all",
         "-a",

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -80,6 +80,16 @@ def list_projects(obj: ProjectsContext):
         obj.cli.console.print(Markdown(f"{proj} `{name}`"))
 
 
+@projects.command(name="names", help="List found projects names")
+@click.pass_obj
+def list_project_names(obj: ProjectsContext):
+    found_projects = obj.cli.repo.find_projects(obj.filter)
+
+    for proj in found_projects:
+        name = load_project(obj.cli.repo.root_dir(), Path(proj), False).name
+        obj.cli.console.print(name)
+
+
 class ProjectPath(ParamType):
     name = "project_path"
 

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -80,7 +80,7 @@ def list_projects(obj: ProjectsContext):
         obj.cli.console.print(Markdown(f"{proj} `{name}`"))
 
 
-@projects.command(name="names", help="List found projects names")
+@projects.command(name="names", help="List found project names")
 @click.pass_obj
 def list_project_names(obj: ProjectsContext):
     found_projects = obj.cli.repo.find_projects(obj.filter)

--- a/tests/cli/test_resources/projects_help_text.txt
+++ b/tests/cli/test_resources/projects_help_text.txt
@@ -10,6 +10,7 @@ Options:
   --help             Show this message and exit.
 
 Commands:
-  lint  Validate the yaml of changed projects against their schema
-  list  List found projects
-  show  Show details of a project
+  lint   Validate the yaml of changed projects against their schema
+  list   List found projects
+  names  List found project names
+  show   Show details of a project


### PR DESCRIPTION
Related monorepo pr: https://github.com/Vandebron/Vandebron/pull/11124
Working example run: https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-171/25/console 

branch: feature/TECH-493-manual-project-selection

----
### 📕 [TECH-493](https://vandebron.atlassian.net/browse/TECH-493) Allow for manual project selection <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Allow users to manually select which projects to deploy, see the 2nd item here [2023-07-26+CI+CD+Guild](https://vandebron.atlassian.net/wiki/spaces/DIG/pages/95581484646441/2023-07-26+CI+CD+Guild) 

🏗️ Build [25](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-171/25/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-171.test.nl/)*, *job*  


[TECH-493]: https://vandebron.atlassian.net/browse/TECH-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ