### PR TITLE
[TECH-486] Add solution for copying secrets to pr namespaces

### DIFF
--- a/src/mpyl/steps/deploy/k8s/__init__.py
+++ b/src/mpyl/steps/deploy/k8s/__init__.py
@@ -92,7 +92,7 @@ def substitute_namespaces(
 
     When the env var is substituted, first the referenced service (serviceName) is looked up in the list of projects.
     If it is part of the deploy set, and we're in deploying to target PullRequest,
-    the namespace is subsituted with the PR namespace (pr-XXXX).
+    the namespace is substituted with the PR namespace (pr-XXXX).
     Else is substituted with the namespace of the referenced project.
 
     Note that the name of the service in the env var is case-sensitive!

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -6,7 +6,7 @@ import itertools
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from kubernetes import config
+from kubernetes import config as k8s_config
 from kubernetes.client import (
     V1Deployment,
     V1Container,
@@ -550,7 +550,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
             ranger_config = cluster_config(
                 self.step_input.run_properties.target, self.step_input.run_properties
             )
-            config.load_kube_config(context=ranger_config.context)
+            k8s_config.load_kube_config(context=ranger_config.context)
             #  Use context="vdb-core-digital-k8s-test-fqdn" for local testing
             kubernetes_api = CoreV1Api()
             cluster_secrets: V1SecretList = kubernetes_api.list_namespaced_secret(

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -546,12 +546,12 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
 
         if (
             self.step_input.run_properties.target == Target.PULL_REQUEST
-        ):  # and not step_input.dry_run:
-            ranger_config = cluster_config(
+            and not self.step_input.dry_run
+        ):
+            rancher_config = cluster_config(
                 self.step_input.run_properties.target, self.step_input.run_properties
             )
-            k8s_config.load_kube_config(context=ranger_config.context)
-            #  Use context="vdb-core-digital-k8s-test-fqdn" for local testing
+            k8s_config.load_kube_config(context=rancher_config.context)
             kubernetes_api = CoreV1Api()
             cluster_secrets: V1SecretList = kubernetes_api.list_namespaced_secret(
                 namespace=self.deployment.namespace  # Should be source namespace?
@@ -566,7 +566,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
                     == defined_secret.value_from.get("secretKeyRef").get("name")
                 )
             )
-            pr_namespace = "cypress"  # Should be pr namespace
+            pr_namespace = self.step_input.run_properties.versioning.identifier
             for secret_to_copy in secrets_to_copy:
                 secret_to_copy.metadata.resource_version = None
                 secret_to_copy.metadata.namespace = pr_namespace

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -521,8 +521,9 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
         k8s_config.load_kube_config(context=rancher_config.context)
         kubernetes_api = CoreV1Api()
 
+        project_namespace = self.deployment.namespace or self.step_input.project.name
         cluster_secrets: V1SecretList = kubernetes_api.list_namespaced_secret(
-            namespace=self.deployment.namespace, async_req=True
+            namespace=project_namespace, async_req=True
         ).get()
         secrets_to_copy: list[V1Secret] = []
         for requested_secret in self.secrets:

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -66,6 +66,7 @@ class TestKubernetesChart:
                 project,
                 run_properties=test_data.RUN_PROPERTIES,
                 required_artifact=required_artifact,
+                dry_run=True,
             ),
             deploy_set=DeploySet({project, other_project}, {project}),
         )

--- a/tests/test_resources/test_job_project.yml
+++ b/tests/test_resources/test_job_project.yml
@@ -6,6 +6,7 @@ stages:
   test: "Echo Test"
   deploy: "Kubernetes Job Deploy"
 deployment:
+  namespace: "batterypack-jobs"
   properties:
     env:
       - key: PROD_ONLY_ENV
@@ -16,6 +17,13 @@ deployment:
         test: "AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg=="
         acceptance: "Acceptance"
         production: "Production"
+    kubernetes:
+      - key: PG_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: "aapsyncjob"
+            key: password
+            optional: false
   kubernetes:
     job:
       ttlSecondsAfterFinished:

--- a/tests/test_resources/test_job_project.yml
+++ b/tests/test_resources/test_job_project.yml
@@ -6,7 +6,6 @@ stages:
   test: "Echo Test"
   deploy: "Kubernetes Job Deploy"
 deployment:
-  namespace: "batterypack-jobs"
   properties:
     env:
       - key: PROD_ONLY_ENV
@@ -17,13 +16,6 @@ deployment:
         test: "AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg=="
         acceptance: "Acceptance"
         production: "Production"
-    kubernetes:
-      - key: PG_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: "aapsyncjob"
-            key: password
-            optional: false
   kubernetes:
     job:
       ttlSecondsAfterFinished:


### PR DESCRIPTION
branch: feature/TECH-486-copy-k8s-secrets-for-prs

----
### 📕 [TECH-486](https://vandebron.atlassian.net/browse/TECH-486) Copy k8s secrets for PR environments <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
**What**

In the new postgres deploy approach by platform: [Deploy+Postgres](https://vandebron.atlassian.net/wiki/spaces/DIG/pages/95581353148450/Deploy+Postgres) , they create the postgres deployment for the development teams, together with a k8s secret containing the password, which can be mounted on the deployment by specifying it in the project yamls like:

```
deployment:
  properties:
    kubernetes:
      - key: PG_PASSWORD
        valueFrom:
          secretKeyRef:
            name: "<your-postgres-name>-postgres-vdb-user"
            key: password
            optional: false```


This does not work for PR deployments though, so we need to manually copy the secret to the PR namespace by doing:

{noformat}kubectl get -n <SOURCE*NAMESPACE> secrets/<SECRET*NAME> -o yaml \
  | sed s/"namespace: <SOURCE*NAMESPACE>"/"namespace: <DESTINATION*NAMESPACE>"/ \
  | kubectl apply -n <DESTINATION_NAMESPACE> -f -
```

We can try to automate this via MPyL.

**How**

In case there are “plain” secrets referenced in the project yaml, and we’re in PR environment, we can copy the secrets to our namespace by 

- getting the secret using the source namespace in the project yaml and name of the secret
- modifying/creating a new secret in code with the same contents and adding it to the templates
- applying that secret together in the `Kubernetes Deploy` step
```

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-184/3/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-184.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-184.test.nl/)*, *[sbtservice](https://sbtservice-184.test.nl/)*, *sparkJob*  


[TECH-486]: https://vandebron.atlassian.net/browse/TECH-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ