### PR TITLE
[TECH-529] Implement service monitor chart

### DIFF
--- a/src/mpyl/cli/health.py
+++ b/src/mpyl/cli/health.py
@@ -1,7 +1,6 @@
 """Health check command"""
 
 import click
-from rich.console import Console
 
 from . import create_console_logger
 from .commands.health.checks import perform_health_checks
@@ -17,7 +16,5 @@ from .commands.health.checks import perform_health_checks
 )
 def health(is_ci):
     """Health check"""
-    console: Console = create_console_logger(
-        show_path=False, verbose=False, max_width=0
-    )
+    console = create_console_logger(show_path=False, verbose=False, max_width=0)
     perform_health_checks(console, is_ci)

--- a/src/mpyl/steps/deploy/k8s/__init__.py
+++ b/src/mpyl/steps/deploy/k8s/__init__.py
@@ -19,11 +19,11 @@ from ....steps.deploy.k8s.rancher import (
 )
 
 
-def get_namespace(run_properties: RunProperties, project: Project) -> Optional[str]:
+def get_namespace(run_properties: RunProperties, project: Project) -> str:
     if run_properties.target == Target.PULL_REQUEST:
         return run_properties.versioning.identifier
 
-    return get_namespace_from_project(project)
+    return get_namespace_from_project(project) or project.name
 
 
 def get_namespace_from_project(project: Project) -> Optional[str]:
@@ -76,8 +76,7 @@ def deploy_helm_chart(
     if render_templates(run_properties):
         return helm.template(logger, chart_path, release_name)
 
-    namespace = get_namespace(run_properties, project) or project.name
-
+    namespace = get_namespace(run_properties, project)
     rancher_config: ClusterConfig = cluster_config(target, run_properties)
     upsert_namespace(logger, namespace, dry_run, run_properties, rancher_config)
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -160,7 +160,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
     release_name: str
     config_defaults: DeploymentDefaults
     deploy_set: Optional[DeploySet]
-    namespace: Optional[str]
+    namespace: str
 
     def __init__(self, step_input: Input, deploy_set: Optional[DeploySet] = None):
         self.step_input = step_input

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -356,17 +356,12 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
         )
 
     def to_service_monitor(self, metrics: Metrics) -> V1ServiceMonitor:
-        endpoint = {
-            "honorLabels": True,
-            "path": metrics.path or "/metrics",
-            "targetPort": metrics.port or self.__find_default_port(),
-        }
-
         return V1ServiceMonitor(
             metadata=self._to_object_meta(
                 name=f"{self.project.name.lower()}-service-monitor"
             ),
-            endpoint=endpoint,
+            metrics=metrics,
+            default_port=self.__find_default_port(),
             namespace=self.namespace,
         )
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -357,7 +357,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
 
     def to_service_monitor(self, metrics: Metrics) -> V1ServiceMonitor:
         endpoint = {
-            "honorLabels": "true",
+            "honorLabels": True,
             "path": metrics.path or "/metrics",
             "targetPort": metrics.port or self.__find_default_port(),
         }

--- a/src/mpyl/steps/deploy/k8s/resources/prometheus.py
+++ b/src/mpyl/steps/deploy/k8s/resources/prometheus.py
@@ -1,6 +1,7 @@
 """
 This module contains the PrometheusRule CRD
 """
+from typing import Optional
 
 from kubernetes.client import V1ObjectMeta
 
@@ -46,7 +47,9 @@ def _alerts_to_rules(alerts: list[Alert]) -> list[dict]:
 
 
 class V1ServiceMonitor(CustomResourceDefinition):
-    def __init__(self, metadata: V1ObjectMeta, endpoint: dict, namespace: str):
+    def __init__(
+        self, metadata: V1ObjectMeta, endpoint: dict, namespace: Optional[str]
+    ):
         super().__init__(
             api_version="monitoring.coreos.com/v1",
             kind="ServiceMonitor",

--- a/src/mpyl/steps/deploy/k8s/resources/prometheus.py
+++ b/src/mpyl/steps/deploy/k8s/resources/prometheus.py
@@ -1,8 +1,6 @@
 """
 This module contains the PrometheusRule CRD
 """
-from typing import Optional
-
 from kubernetes.client import V1ObjectMeta
 
 from .....project import Alert, Metrics
@@ -52,7 +50,7 @@ class V1ServiceMonitor(CustomResourceDefinition):
         metadata: V1ObjectMeta,
         metrics: Metrics,
         default_port: int,
-        namespace: Optional[str],
+        namespace: str,
     ):
         super().__init__(
             api_version="monitoring.coreos.com/v1",

--- a/src/mpyl/steps/deploy/k8s/resources/prometheus.py
+++ b/src/mpyl/steps/deploy/k8s/resources/prometheus.py
@@ -8,6 +8,24 @@ from .....project import Alert
 from .. import CustomResourceDefinition
 
 
+class V1PrometheusRule(CustomResourceDefinition):
+    def __init__(self, metadata: V1ObjectMeta, alerts: list[Alert]):
+        super().__init__(
+            api_version="monitoring.coreos.com/v1",
+            kind="PrometheusRule",
+            metadata=metadata,
+            schema="monitoring.coreos.com_prometheuses.schema.yml",
+            spec={
+                "groups": [
+                    {
+                        "name": f"{metadata.name}-group",
+                        "rules": _alerts_to_rules(alerts),
+                    }
+                ]
+            },
+        )
+
+
 def _alerts_to_rules(alerts: list[Alert]) -> list[dict]:
     return [
         {
@@ -27,19 +45,16 @@ def _alerts_to_rules(alerts: list[Alert]) -> list[dict]:
     ]
 
 
-class V1PrometheusRule(CustomResourceDefinition):
-    def __init__(self, metadata: V1ObjectMeta, alerts: list[Alert]):
+class V1ServiceMonitor(CustomResourceDefinition):
+    def __init__(self, metadata: V1ObjectMeta, endpoint: dict, namespace: str):
         super().__init__(
             api_version="monitoring.coreos.com/v1",
-            kind="PrometheusRule",
+            kind="ServiceMonitor",
             metadata=metadata,
-            schema="monitoring.coreos.com_prometheuses.schema.yml",
+            schema="monitoring.coreos.com_servicemonitors.schema.yml",
             spec={
-                "groups": [
-                    {
-                        "name": f"{metadata.name}-group",
-                        "rules": _alerts_to_rules(alerts),
-                    }
-                ]
+                "endpoints": [endpoint],
+                "namespaceSelector": {"matchNames": [namespace]},
+                "selector": {"matchLabels": {"app.kubernetes.io/name": metadata.name}},
             },
         )

--- a/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_prometheuses.schema.yml
+++ b/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_prometheuses.schema.yml
@@ -1,3 +1,4 @@
+# source: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_servicemonitors.schema.yml
+++ b/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_servicemonitors.schema.yml
@@ -1,0 +1,714 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: servicemonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+      - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    shortNames:
+      - smon
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ServiceMonitor defines monitoring for a set of services.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of desired Service selection for target discovery
+                by Prometheus.
+              properties:
+                attachMetadata:
+                  description: Attaches node metadata to discovered targets. Requires
+                    Prometheus v2.37.0 and above.
+                  properties:
+                    node:
+                      description: When set to true, Prometheus must have permissions
+                        to get Nodes.
+                      type: boolean
+                  type: object
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceMonitor.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      authorization:
+                        description: Authorization section for this endpoint
+                        properties:
+                          credentials:
+                            description: Selects a key of a Secret in the namespace
+                              that contains the credentials for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type:
+                            description: "Defines the authentication type. The value
+                            is case-insensitive. \n \"Basic\" is not a supported value.
+                            \n Default: \"Bearer\""
+                            type: string
+                        type: object
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service monitor namespace
+                              that contains the password for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          username:
+                            description: The secret in the service monitor namespace
+                              that contains the username for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as the
+                          service monitor and accessible by the Prometheus Operator.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      enableHttp2:
+                        description: Whether to enable HTTP2.
+                        type: boolean
+                      filterRunning:
+                        description: 'Drop pods that are not running. (Failed, Succeeded).
+                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                        type: boolean
+                      followRedirects:
+                        description: FollowRedirects configures whether scrape requests
+                          follow HTTP 3xx redirects.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether Prometheus respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped If
+                          not specified Prometheus' global scrape interval is used.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      metricRelabelings:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: "RelabelConfig allows dynamic rewriting of the
+                          label set for targets, alerts, scraped samples and remote
+                          write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                          properties:
+                            action:
+                              default: replace
+                              description: "Action to perform based on the regex matching.
+                              \n `Uppercase` and `Lowercase` actions require Prometheus
+                              >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                              Prometheus >= v2.41.0. \n Default: \"Replace\""
+                              enum:
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
+                              type: string
+                            modulus:
+                              description: "Modulus to take of the hash of the source
+                              label values. \n Only applicable when the action is
+                              `HashMod`."
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched.
+                              type: string
+                            replacement:
+                              description: "Replacement value against which a Replace
+                              action is performed if the regular expression matches.
+                              \n Regex capture groups are available."
+                              type: string
+                            separator:
+                              description: Separator is the string between concatenated
+                                SourceLabels.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                Separator and matched against the configured regular
+                                expression.
+                              items:
+                                description: LabelName is a valid Prometheus label name
+                                  which may only contain ASCII letters, numbers, as
+                                  well as underscores.
+                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: "Label to which the resulting string is written
+                              in a replacement. \n It is mandatory for `Replace`,
+                              `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and
+                              `DropEqual` actions. \n Regex capture groups are available."
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 for the URL. Only valid in Prometheus versions
+                          2.27.0 and newer.
+                        properties:
+                          clientId:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          clientSecret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          endpointParams:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          tokenUrl:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                          - clientId
+                          - clientSecret
+                          - tokenUrl
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics. If empty, Prometheus
+                          uses the default value (e.g. `/metrics`).
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers to.
+                          Mutually exclusive with targetPort.
+                        type: string
+                      proxyUrl:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelings:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields. The original scrape job''s name
+                        is available via the `__tmp_prometheus_job_name` label. More
+                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: "RelabelConfig allows dynamic rewriting of the
+                          label set for targets, alerts, scraped samples and remote
+                          write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                          properties:
+                            action:
+                              default: replace
+                              description: "Action to perform based on the regex matching.
+                              \n `Uppercase` and `Lowercase` actions require Prometheus
+                              >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                              Prometheus >= v2.41.0. \n Default: \"Replace\""
+                              enum:
+                                - replace
+                                - Replace
+                                - keep
+                                - Keep
+                                - drop
+                                - Drop
+                                - hashmod
+                                - HashMod
+                                - labelmap
+                                - LabelMap
+                                - labeldrop
+                                - LabelDrop
+                                - labelkeep
+                                - LabelKeep
+                                - lowercase
+                                - Lowercase
+                                - uppercase
+                                - Uppercase
+                                - keepequal
+                                - KeepEqual
+                                - dropequal
+                                - DropEqual
+                              type: string
+                            modulus:
+                              description: "Modulus to take of the hash of the source
+                              label values. \n Only applicable when the action is
+                              `HashMod`."
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched.
+                              type: string
+                            replacement:
+                              description: "Replacement value against which a Replace
+                              action is performed if the regular expression matches.
+                              \n Regex capture groups are available."
+                              type: string
+                            separator:
+                              description: Separator is the string between concatenated
+                                SourceLabels.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                Separator and matched against the configured regular
+                                expression.
+                              items:
+                                description: LabelName is a valid Prometheus label name
+                                  which may only contain ASCII letters, numbers, as
+                                  well as underscores.
+                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: "Label to which the resulting string is written
+                              in a replacement. \n It is mandatory for `Replace`,
+                              `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and
+                              `DropEqual` actions. \n Regex capture groups are available."
+                              type: string
+                          type: object
+                        type: array
+                      scheme:
+                        description: HTTP scheme to use for scraping. `http` and `https`
+                          are the expected values unless you rewrite the `__scheme__`
+                          label via relabeling. If empty, Prometheus uses the default
+                          value `http`.
+                        enum:
+                          - http
+                          - https
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended If not
+                          specified, the Prometheus global scrape timeout is used unless
+                          it is less than `Interval` in which the latter is used.
+                        pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                        type: string
+                      targetPort:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Name or number of the target port of the Pod behind
+                          the Service, the port must be specified with container port
+                          property. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLS configuration to use when scraping the endpoint
+                        properties:
+                          ca:
+                            description: Certificate authority used when verifying server
+                              certificates.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the Prometheus container
+                              to use for the targets.
+                            type: string
+                          cert:
+                            description: Client certificate to present when doing client-authentication.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the Prometheus
+                              container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the Prometheus
+                              container for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for the
+                              targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: "JobLabel selects the label from the associated Kubernetes
+                  service which will be used as the `job` label for all metrics. \n
+                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
+                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
+                  the value of this field is empty or if the label doesn't exist for
+                  the given Service, the `job` label of the metrics defaults to the
+                  name of the Kubernetes Service."
+                  type: string
+                labelLimit:
+                  description: Per-scrape limit on number of labels that will be accepted
+                    for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                  format: int64
+                  type: integer
+                labelNameLengthLimit:
+                  description: Per-scrape limit on length of labels name that will be
+                    accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                labelValueLengthLimit:
+                  description: Per-scrape limit on length of labels value that will
+                    be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                namespaceSelector:
+                  description: Selector to select which namespaces the Kubernetes Endpoints
+                    objects are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names to select from.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                    onto the created metrics.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                targetLabels:
+                  description: TargetLabels transfers labels from the Kubernetes `Service`
+                    onto the created metrics.
+                  items:
+                    type: string
+                  type: array
+                targetLimit:
+                  description: TargetLimit defines a limit on the number of scraped
+                    targets that will be accepted.
+                  format: int64
+                  type: integer
+              required:
+                - endpoints
+                - selector
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_servicemonitors.schema.yml
+++ b/src/mpyl/steps/deploy/k8s/resources/schema/monitoring.coreos.com_servicemonitors.schema.yml
@@ -1,3 +1,4 @@
+# source: "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/tests/projects/cloudfront/deployment/project.yml
+++ b/tests/projects/cloudfront/deployment/project.yml
@@ -15,6 +15,7 @@ dependencies:
   build:
     - 'test/docker/'
 deployment:
+  namespace: "cloudfront-service"
   properties:
     env:
       - key: SOME_ENV
@@ -30,7 +31,7 @@ deployment:
     portMappings:
       8081: 8081
     metrics:
-      enabled: false
+      enabled: true
     resources:
       instances:
         all: 1

--- a/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
@@ -14,7 +14,7 @@ metadata:
   name: dockertest-service-monitor
 spec:
   endpoints:
-  - honorLabels: 'true'
+  - honorLabels: true
     path: /metrics
     targetPort: 8080
   namespaceSelector:

--- a/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-service-monitor
+spec:
+  endpoints:
+  - honorLabels: 'true'
+    path: /metrics
+    targetPort: 8080
+  namespaceSelector:
+    matchNames:
+    - pr-1234
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dockertest-service-monitor

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -154,6 +154,7 @@ class TestKubernetesChart:
             "dockertest-ingress-0-whitelist",
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
+            "service-monitor",
         ],
     )
     def test_service_chart_roundtrip(self, template):
@@ -169,6 +170,7 @@ class TestKubernetesChart:
             "dockertest-ingress-0-whitelist",
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
+            "service-monitor",
         }
 
     def test_default_ingress(self):


### PR DESCRIPTION
branch: feature/TECH-529-implement-service-monitor

----
### 📕 [TECH-529](https://vandebron.atlassian.net/browse/TECH-529) Missing ServiceMonitor for prometheus alerts <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
[p1692280104683939](https://vandebron.slack.com/archives/C04KP2UFMMJ/p1692280104683939) 

🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-189/5/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-189.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-189.test.nl/)*, *[sbtservice](https://sbtservice-189.test.nl/)*, *sparkJob*  


[TECH-529]: https://vandebron.atlassian.net/browse/TECH-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ