### PR TITLE
[TECH-435] Fix jenkins dryrun

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
                             sh "pipenv run mpyl build status"
+                            echo "BUILD_PARAMS ${params.BUILD_PARAMS}"
                             sh "pipenv run run-ci ${params.BUILD_PARAMS}"
                         }
                     }

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -132,6 +132,9 @@ if __name__ == "__main__":
     parsed_args = parser.parse_args()
     mpl_logger = logging.getLogger("mpyl")
     mpl_logger.info("Starting run.....")
+
+    print(f"PARSED_ARGS: {parsed_args}")
+
     try:
         main(mpl_logger, parsed_args)
     except Exception as e:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -336,6 +336,14 @@ def ask_for_input(ctx, _param, value) -> Optional[str]:
     default="not_set",
     callback=ask_for_input,
 )
+@click.option(
+    "--dryrun",
+    "-d",
+    help="don't push or deploy images",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
 @click.pass_context
 def jenkins(  # pylint: disable=too-many-arguments
     ctx,
@@ -347,6 +355,7 @@ def jenkins(  # pylint: disable=too-many-arguments
     background,
     silent,
     tag,
+    dryrun,
 ):
     upgrade_check = None
     try:
@@ -361,8 +370,13 @@ def jenkins(  # pylint: disable=too-many-arguments
 
         selected_pipeline = pipeline if pipeline else jenkins_config["defaultPipeline"]
         pipeline_parameters = {"TEST": "true", "VERSION": test} if test else {}
+
+        if dryrun:
+            arguments = arguments + ("--dryrun",)
+
         if arguments:
             pipeline_parameters["BUILD_PARAMS"] = " ".join(arguments)
+            print(f'PPP: {pipeline_parameters["BUILD_PARAMS"]}')
 
         run_argument = JenkinsRunParameters(
             jenkins_user=user,


### PR DESCRIPTION
branch: feature/TECH-435-CLI-DRYRUN

----
### 📕 [TECH-435](https://vandebron.atlassian.net/browse/TECH-435) CLI improvements <img src="https://secure.gravatar.com/avatar/22987b802af30079346039ff7c67e6fa?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FES-1.png" width="24" height="24" alt="ewaldschrader@vandebron.nl" /> 
Add support for the following things in the CLI

* do a dry run
* set mpyl version of jenkins run (currently we can only set test version)
* deploy parameters 
* other build parameters?

----

We should be able to set the parameters for Jenkins via the cli like:

```
mpyl build jenkins --argument "run run --dryrun"```


→ this probably doesn’t work with `click` . 

- Define custom argument type with click
- Parse string argument

Another (maybe better) option is to just add a dryrun flag for mpyl cli, and then pass that on to jenkins via the jenkins API:

{noformat}mpyl build jenkins --dryrun
```
```

🏗️ Build [19](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-191/19/display/redirect) 🦥 Nothing to do, started by _Ewald Schrader_  


[TECH-435]: https://vandebron.atlassian.net/browse/TECH-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ