### PR TITLE
[TECH-477] Updating AWS credential requirements

### DIFF
--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -347,10 +347,14 @@ class Traefik:
 @dataclass(frozen=True)
 class S3Bucket:
     bucket: TargetProperty[str]
+    region: str
 
     @staticmethod
     def from_config(values: dict):
-        return S3Bucket(bucket=TargetProperty.from_config(values.get("bucket", {})))
+        return S3Bucket(
+            bucket=TargetProperty.from_config(values.get("bucket", {})),
+            region=values.get("region", {}),
+        )
 
 
 @dataclass(frozen=True)

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -363,6 +363,3 @@ definitions:
         type: string
       secretAccessKey:
         type: string
-    required:
-      - accessKeyId
-      - secretAccessKey

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -360,6 +360,9 @@ definitions:
     type: object
     properties:
       accessKeyId:
-        type: string
+        type: [ string, null ]
       secretAccessKey:
-        type: string
+        type: [ string, null ]
+    dependencies:
+      accessKeyId: [ secretAccessKey ]
+      secretAccessKey: [ accessKeyId ]

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -206,9 +206,12 @@ properties:
         type: object
         required:
           - bucket
+          - region
         properties:
           bucket:
             $ref: '#/definitions/dtapValue'
+          region:
+            type: string
           path:
             $ref: '#/definitions/dtapValue'
       kubernetes:

--- a/src/mpyl/steps/deploy/cloudfront_kubernetes_deploy.py
+++ b/src/mpyl/steps/deploy/cloudfront_kubernetes_deploy.py
@@ -61,16 +61,23 @@ class CloudFrontKubernetesDeploy(Step):
         Creates an S3 client and uploads the static assets stored in the temp folder
         """
         logger.info("Creating S3 client")
+
         bucket_name = step_input.project.s3_bucket.bucket.get_value(
             step_input.run_properties.target
         )
+        bucket_region = step_input.project.s3_bucket.region
+
         s3_config = S3ClientConfig(
-            run_properties=step_input.run_properties, bucket_name=bucket_name
+            run_properties=step_input.run_properties,
+            bucket_name=bucket_name,
+            bucket_region=bucket_region,
         )
         s3_client = S3Client(logger, s3_config)
 
         logger.info(
             f"Uploading assets to '{s3_config.bucket_root_path}' in bucket '{s3_config.bucket_name}'"
         )
-        s3_client.upload_directory(directory=tmp_folder)
+        s3_client.upload_directory(
+            directory=tmp_folder, root_asset_location=STATIC_FOLDER
+        )
         logger.info("Upload complete")

--- a/src/mpyl/utilities/s3/__init__.py
+++ b/src/mpyl/utilities/s3/__init__.py
@@ -15,17 +15,18 @@ from ...steps.models import RunProperties
 
 @dataclass
 class S3ClientConfig:
-    service_name = "s3"
-    region_name = "eu-central-1"
-    access_key_id: Optional[str]
-    secret_access_key: Optional[str]
     bucket_name: str
     bucket_root_path: str
+    service_name = "s3"
+    region_name = "eu-central-1"
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
 
     def __init__(self, run_properties: RunProperties, bucket_name: str):
-        s3_connection_info = run_properties.config.get("s3", None)
-        self.access_key_id = s3_connection_info.get("accessKeyId")
-        self.secret_access_key = s3_connection_info.get("secretAccessKey")
+        s3_connection_info = run_properties.config.get("s3")
+        if s3_connection_info is not None:
+            self.access_key_id = s3_connection_info.get("accessKeyId")
+            self.secret_access_key = s3_connection_info.get("secretAccessKey")
         self.bucket_name = bucket_name
         self.bucket_root_path = run_properties.versioning.identifier
 
@@ -34,6 +35,10 @@ class S3Client:
     def __init__(self, logger: Logger, config: S3ClientConfig):
         """
         Creates a client that provides a wrapper for uploading a directory to an S3 bucket
+
+        Credentials can be provided via the s3.accessKeyId and s3.secretAccessKey properties in the mpyl_config or
+        via the numerous ways supported by boto3 (see
+        https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
 
         :param config: the S3 client config containing the necessary credentials and bucket information
         """

--- a/tests/projects/cloudfront/deployment/project.yml
+++ b/tests/projects/cloudfront/deployment/project.yml
@@ -60,3 +60,4 @@ deployment:
       test: mpyl-cloudfront-aws-test-bucket
       acceptance: mpyl-cloudfront-aws-test-bucket
       production: mpyl-cloudfront-aws-test-bucket
+    region: "eu-central-1"

--- a/tests/utilities/test_s3.py
+++ b/tests/utilities/test_s3.py
@@ -4,25 +4,38 @@ from src.mpyl.utilities.s3 import S3Client
 class TestS3:
     def test_create_dst_path_succeeds(self):
         bucket_path1 = S3Client.create_file_dst(
-            root_path="root", file_path="/tmp/asVx3sd/", filename="filename.js"
+            root_path="root",
+            file_path="/tmp/asVx3sd/static",
+            filename="filename.js",
+            root_asset_location="static",
         )
         bucket_path2 = S3Client.create_file_dst(
-            root_path="root", file_path="/tmp/asVx3sd/js", filename="filename.js"
+            root_path="root",
+            file_path="/tmp/asVx3sd/static/js",
+            filename="filename.js",
+            root_asset_location="static",
         )
         bucket_path3 = S3Client.create_file_dst(
-            root_path="root", file_path="/tmp/asVx3sd/css", filename="filename.css"
+            root_path="root",
+            file_path="/tmp/asVx3sd/static/css",
+            filename="filename.css",
+            root_asset_location="static",
         )
         bucket_path4 = S3Client.create_file_dst(
-            root_path="root", file_path="/tmp/asVx3sd/assets", filename="filename.jpg"
+            root_path="root",
+            file_path="/tmp/asVx3sd/static/assets",
+            filename="filename.jpg",
+            root_asset_location="static",
         )
         bucket_path5 = S3Client.create_file_dst(
             root_path="root",
-            file_path="/tmp/asVx3sd/assets/docs",
+            file_path="/tmp/asVx3sd/static/assets/docs",
             filename="filename.pdf",
+            root_asset_location="static",
         )
 
-        assert bucket_path1 == "root/filename.js"
-        assert bucket_path2 == "root/js/filename.js"
-        assert bucket_path3 == "root/css/filename.css"
-        assert bucket_path4 == "root/assets/filename.jpg"
-        assert bucket_path5 == "root/assets/docs/filename.pdf"
+        assert bucket_path1 == "root/static/filename.js"
+        assert bucket_path2 == "root/static/js/filename.js"
+        assert bucket_path3 == "root/static/css/filename.css"
+        assert bucket_path4 == "root/static/assets/filename.jpg"
+        assert bucket_path5 == "root/static/assets/docs/filename.pdf"


### PR DESCRIPTION
Making the access and secret keys optional in the config as it's very common to use AWS credential or config files for authentication. Boto3 will automatically look for these files if nothing is passed to the client.

branch:feature/TECH-477-aws-credentials

local build reading from credentials file:
<img width="940" alt="Screenshot 2023-08-28 at 11 39 34" src="https://github.com/Vandebron/mpyl/assets/121795724/39810e6b-ebf8-4ff3-ab74-fe165cf8d017">



----
### 📕 [TECH-477](https://vandebron.atlassian.net/browse/TECH-477) Read AWS credentials from credentials file instead of specifying env vars <img src="https://secure.gravatar.com/avatar/837553f1c1c5ef2c8c49a32d50be6b22?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FBL-5.png" width="24" height="24" alt="benjaminlynch@vandebron.nl" /> 
Use `boto3}} or read manually from {{~/.aws/credentials` if there are no AWS environment variables



github token is handled at: `mpyl.cli.commands.build.jenkins.get_token` as an example

🏗️ Build [19](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-196/19/display/redirect) ✅ Successful, started by _Ben Lynch_  
🚀 *[cloudfront-service](https://cloudfront-service-196.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-196.test.nl/)*, *[sbtservice](https://sbtservice-196.test.nl/)*, *sparkJob*  


[TECH-477]: https://vandebron.atlassian.net/browse/TECH-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ