### PR TITLE
Correctly parse resource requests and replica count

### DIFF
--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -250,20 +250,32 @@ class Metrics:
 
 
 @dataclass(frozen=True)
-class Resources:
-    instances: Optional[TargetProperty[int]]
+class ResourceSpecification:
     cpus: Optional[TargetProperty[float]]
     mem: Optional[TargetProperty[int]]
     disk: Optional[TargetProperty[int]]
 
     @staticmethod
     def from_config(values: dict):
-        limits = values.get("limit", {})
+        return ResourceSpecification(
+            cpus=TargetProperty.from_config(values.get("cpus", {})),
+            mem=TargetProperty.from_config(values.get("mem", {})),
+            disk=TargetProperty.from_config(values.get("disk", {})),
+        )
+
+
+@dataclass(frozen=True)
+class Resources:
+    instances: Optional[TargetProperty[int]]
+    limit: Optional[ResourceSpecification]
+    request: Optional[ResourceSpecification]
+
+    @staticmethod
+    def from_config(values: dict):
         return Resources(
-            instances=TargetProperty.from_config(limits.get("instances", {})),
-            cpus=TargetProperty.from_config(limits.get("cpus", {})),
-            mem=TargetProperty.from_config(limits.get("mem", {})),
-            disk=TargetProperty.from_config(limits.get("disk", {})),
+            instances=TargetProperty.from_config(values.get("instances", {})),
+            limit=ResourceSpecification.from_config(values.get("limit", {})),
+            request=ResourceSpecification.from_config(values.get("request", {})),
         )
 
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -454,30 +454,36 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
         return V1SealedSecret(name=self.release_name, secrets=secrets)
 
     @staticmethod
-    def _to_resources(resources: Resources, defaults: ResourceDefaults, target: Target):
+    def _to_resource_requirements(
+        resources: Resources, defaults: ResourceDefaults, target: Target
+    ):
         cpus = (
             resources.limit.cpus
-            if resources and resources.limit and resources.limit.cpus
+            if resources.limit and resources.limit.cpus
             else defaults.cpus
         )
-        cpus_limit = cpus.get_value(target=target) * 1000.0
-        cpus_request = (
-            resources.request.cpus
-            if resources and resources.request and resources.request.cpus
+
+        cpus_limit: float = cpus.get_value(target=target) * 1000.0
+
+        cpus_request: float = (
+            resources.request.cpus.get_value(target=target) * 1000.0
+            if resources.request and resources.request.cpus
             else cpus_limit * CPU_REQUEST_SCALE_FACTOR
         )
 
         mem = (
             resources.limit.mem
-            if resources and resources.limit and resources.limit.mem
+            if resources.limit and resources.limit.mem
             else defaults.mem
         )
-        mem_limit = mem.get_value(target=target)
-        mem_request = (
-            resources.request.mem
-            if resources and resources.request and resources.request.mem
+        mem_limit: float = mem.get_value(target=target)
+
+        mem_request: float = (
+            resources.request.mem.get_value(target=target)
+            if resources.request and resources.request.mem
             else mem_limit * MEM_REQUEST_SCALE_FACTOR
         )
+
         return V1ResourceRequirements(
             limits={"cpu": f"{int(cpus_limit)}m", "memory": f"{int(mem_limit)}Mi"},
             requests={
@@ -498,7 +504,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
     def _get_resources(self):
         resources = self.project.kubernetes.resources
         defaults = self.config_defaults.resources_defaults
-        return ChartBuilder._to_resources(resources, defaults, self.target)
+        return ChartBuilder._to_resource_requirements(resources, defaults, self.target)
 
     def _get_kubernetes(self) -> Kubernetes:
         kubernetes = self.deployment.kubernetes
@@ -591,7 +597,9 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
             env=self._get_env_vars(),
             ports=ports,
             image_pull_policy="Always",
-            resources=ChartBuilder._to_resources(resources, defaults, self.target),
+            resources=ChartBuilder._to_resource_requirements(
+                resources, defaults, self.target
+            ),
             liveness_probe=ChartBuilder._to_probe(
                 kubernetes.liveness_probe,
                 self.config_defaults.liveness_probe_defaults,

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -455,13 +455,29 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
 
     @staticmethod
     def _to_resources(resources: Resources, defaults: ResourceDefaults, target: Target):
-        cpus = resources.cpus if resources and resources.cpus else defaults.cpus
+        cpus = (
+            resources.limit.cpus
+            if resources and resources.limit and resources.limit.cpus
+            else defaults.cpus
+        )
         cpus_limit = cpus.get_value(target=target) * 1000.0
-        cpus_request = cpus_limit * CPU_REQUEST_SCALE_FACTOR
+        cpus_request = (
+            resources.request.cpus
+            if resources and resources.request and resources.request.cpus
+            else cpus_limit * CPU_REQUEST_SCALE_FACTOR
+        )
 
-        mem = resources.mem if resources and resources.mem else defaults.mem
+        mem = (
+            resources.limit.mem
+            if resources and resources.limit and resources.limit.mem
+            else defaults.mem
+        )
         mem_limit = mem.get_value(target=target)
-        mem_request = mem_limit * MEM_REQUEST_SCALE_FACTOR
+        mem_request = (
+            resources.request.mem
+            if resources and resources.request and resources.request.mem
+            else mem_limit * MEM_REQUEST_SCALE_FACTOR
+        )
         return V1ResourceRequirements(
             limits={"cpu": f"{int(cpus_limit)}m", "memory": f"{int(mem_limit)}Mi"},
             requests={

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/instance: dockertest

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             cpu: 500m
             memory: 1024Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 200m
+            memory: 256Mi
       serviceAccount: dockertest
       serviceAccountName: dockertest

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -75,7 +75,7 @@ deployment:
         severity: 'warning'
     resources:
       instances:
-        all: 1
+        all: 3
       limit:
         cpus:
           all: 0.5

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -81,6 +81,11 @@ deployment:
           all: 0.5
         mem:
           all: 1024
+      request:
+        cpus:
+          all: 0.2
+        mem:
+          all: 256
   traefik:
     hosts:
       - host:


### PR DESCRIPTION
- Correctly parse instance (replica) numbers from project yaml (it was not under `deployment.kubernetes.resources.limit` but under `deployment.kubernetes.resources`)
- Take into account not only `deployment.kubernetes.resources.limit` but `deployment.kubernetes.resources.request` as well

----
 # ⚠️ Could not find ticket corresponding to `fix/TECH-XXX_fix_instance_numbers. Does your branch name follow the correct pattern?