### PR TITLE
Feature/tech 548 fix multiple port mapping

### DIFF
--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -380,13 +380,6 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
             self.deployment.traefik.hosts if self.deployment.traefik else []
         )
 
-        first_host = next(iter(hosts), None)
-        default_service_port = (
-            first_host.service_port
-            if first_host and first_host.service_port
-            else self.__find_default_port()
-        )
-
         configured_addresses = self.config_defaults.white_lists["addresses"]
         address_dictionary = {
             address["name"]: address["values"] for address in configured_addresses
@@ -410,7 +403,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
                 index=idx,
                 service_port=host.service_port
                 if host.service_port
-                else default_service_port,
+                else self.__find_default_port(),
                 white_lists=to_white_list(host.whitelists),
             )
             for idx, host in enumerate(hosts if hosts else default_hosts)

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -381,7 +381,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
         )
 
         first_host = next(iter(hosts), None)
-        service_port = (
+        default_service_port = (
             first_host.service_port
             if first_host and first_host.service_port
             else self.__find_default_port()
@@ -408,7 +408,9 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
                 host=host,
                 name=self.release_name,
                 index=idx,
-                service_port=service_port,
+                service_port=host.service_port
+                if host.service_port
+                else default_service_port,
                 white_lists=to_white_list(host.whitelists),
             )
             for idx, host in enumerate(hosts if hosts else default_hosts)

--- a/tests/steps/deploy/k8s/chart/templates/service/ingress-https-route.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/ingress-https-route.yaml
@@ -28,7 +28,7 @@ spec:
     services:
     - name: dockertest
       kind: Service
-      port: 8080
+      port: 4091
     middlewares:
     - name: dockertest-ingress-1-whitelist
     - name: traefik-https-redirect@kubernetescrd


### PR DESCRIPTION


----
### 📕 [TECH-548](https://vandebron.atlassian.net/browse/TECH-548) Traefik multiple port mapping not supported <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-199/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-199.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-199.test.nl/)*, *[sbtservice](https://sbtservice-199.test.nl/)*, *sparkJob*  


[TECH-548]: https://vandebron.atlassian.net/browse/TECH-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ