### PR TITLE
feature/TECH 553 fix startup probes

### DIFF
--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -284,7 +284,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
             else None
         )
 
-        return self.Probes(liveness_probe, startup_probe)
+        return liveness_probe, startup_probe
 
     def to_service(self) -> V1Service:
         service_ports = list(

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -243,11 +243,12 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
         )
 
     @staticmethod
-    def _to_probe(probe: Probe, defaults: dict, target: Target) -> V1Probe:
+    def _to_probe(probe: Optional[Probe], defaults: dict, target: Target) -> V1Probe:
         values = defaults.copy()
-        values.update(probe.values)
+        if probe:
+            values.update(probe.values)
         v1_probe: V1Probe = ChartBuilder._to_k8s_model(values, V1Probe)
-        path = probe.path.get_value(target)
+        path = probe.path.get_value(target) if probe else None
         v1_probe.http_get = V1HTTPGetAction(
             path="/health" if path is None else path, port="port-0"
         )

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -257,11 +257,9 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
     def _construct_probes(self) -> tuple[Optional[V1Probe], Optional[V1Probe]]:
         """
         Construct kubernetes probes based on project yaml values and default values in mpyl_config.yaml.
-        Add a startup probe only if liveness_probe is defined
 
-        NOTE: in MPL the same liveness probe was copied for startup probe,
-              if no startup probe was provided in the project yaml.
-              here we're using the startup probe default values from the config instead
+        NOTE: If no startup probe was provided in the project yaml, but a liveness probe was,
+              this method constructs a startup probe from the default values!
         :return:
         """
         liveness_probe = (

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -93,5 +93,14 @@ spec:
           requests:
             cpu: 200m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 60
+          httpGet:
+            path: /health
+            port: port-0
+          initialDelaySeconds: 4
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 3
       serviceAccount: dockertest
       serviceAccountName: dockertest


### PR DESCRIPTION
See comment in the changes

Basically in MPL we always had a startup probe when we had  liveness probe, in MPyL we didn't. This actually caused many of our services failing to start up when deployed with MPyL..

----
### 📕 [TECH-553](https://vandebron.atlassian.net/browse/TECH-553) Create startupProbe from livenessProbe if not provided <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
[p1693394919992129](https://vandebron.slack.com/archives/CGJDDBETU/p1693394919992129) 

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-201/3/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-201.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-201.test.nl/)*, *[sbtservice](https://sbtservice-201.test.nl/)*, *sparkJob*  


[TECH-553]: https://vandebron.atlassian.net/browse/TECH-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ