### PR TITLE
[TECH-554] Do not reassign ticket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,8 @@ pipeline {
                             sh "pipenv run mpyl version"
                             sh "pipenv run mpyl projects lint --all"
                             sh "pipenv run mpyl health --ci"
-                            sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
+                            sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl build status"
                             sh "pipenv run run-ci ${params.BUILD_PARAMS}"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                             sh "pipenv install -d --skip-lock"
                             sh "pipenv run mpyl version"
                             sh "pipenv run mpyl projects lint --all"
-                            sh "pipenv run mpyl health"
+                            sh "pipenv run mpyl health --ci"
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
                             sh "pipenv run mpyl build status"

--- a/releases/README.md
+++ b/releases/README.md
@@ -28,6 +28,16 @@ The release notes (as you are reading them now) are generated from the `releases
 Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
 instructions, etc. they will be included here.
 
+### Create startup probes by default
+
+When a project is using livenesProbes, but has no startupProbe defined, we resort to creating a startup probe from the
+default values defined in the `mpyl_config.yml` file. This is done to prevent the project from being marked as
+unhealthy.
+
+### Fix namespace interpolation in the Traefik default hosts
+
+The default hosts for Traefik are now interpolated with the namespace of the project in test/acceptance/production.
+
 Details on [Github](https://github.com/Vandebron/mpyl/releases/tag/1.0.11)
 
 ## MPyL 1.0.10

--- a/releases/README.md
+++ b/releases/README.md
@@ -28,13 +28,13 @@ The release notes (as you are reading them now) are generated from the `releases
 Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
 instructions, etc. they will be included here.
 
-### Create startup probes by default
+#### Create startup probes by default
 
 When a project is using livenesProbes, but has no startupProbe defined, we resort to creating a startup probe from the
 default values defined in the `mpyl_config.yml` file. This is done to prevent the project from being marked as
 unhealthy.
 
-### Fix namespace interpolation in the Traefik default hosts
+#### Fix namespace interpolation in the Traefik default hosts
 
 The default hosts for Traefik are now interpolated with the namespace of the project in test/acceptance/production.
 

--- a/releases/notes/1.0.11.md
+++ b/releases/notes/1.0.11.md
@@ -1,4 +1,6 @@
-#### Hotfix for mapping multiple ports to the same service
+# New functionality
+
+### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
 ```yaml

--- a/releases/notes/1.0.11.md
+++ b/releases/notes/1.0.11.md
@@ -1,6 +1,7 @@
 #### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
+
 ```yaml
 deployment:
   kubernetes:
@@ -8,16 +9,29 @@ deployment:
     8081: 8081
   traefik:
     hosts:
-      ...
-      - host:
+        ...
+          - host:
           all: "Host(`some.other.host.com`)"
-        servicePort: 4091
-        priority: 1000
+          servicePort: 4091
+          priority: 1000
 ```
+
 resulted in `8081` being used as servicePort in the treafik rule instead of `4091`.
 
 #### Release notes
 
-The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project repository.
-Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
+The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project
+repository.
+Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes,
+upgrade
 instructions, etc. they will be included here.
+
+### Create startup probes by default
+
+When a project is using livenesProbes, but has no startupProbe defined, we resort to creating a startup probe from the
+default values defined in the `mpyl_config.yml` file. This is done to prevent the project from being marked as
+unhealthy.
+
+### Fix namespace interpolation in the Traefik default hosts
+
+The default hosts for Traefik are now interpolated with the namespace of the project in test/acceptance/production.

--- a/releases/notes/1.0.11.md
+++ b/releases/notes/1.0.11.md
@@ -1,7 +1,6 @@
 #### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
-
 ```yaml
 deployment:
   kubernetes:
@@ -9,21 +8,18 @@ deployment:
     8081: 8081
   traefik:
     hosts:
-        ...
-          - host:
+      ...
+      - host:
           all: "Host(`some.other.host.com`)"
-          servicePort: 4091
-          priority: 1000
+        servicePort: 4091
+        priority: 1000
 ```
-
 resulted in `8081` being used as servicePort in the treafik rule instead of `4091`.
 
 #### Release notes
 
-The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project
-repository.
-Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes,
-upgrade
+The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project repository.
+Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
 instructions, etc. they will be included here.
 
 ### Create startup probes by default

--- a/releases/notes/1.0.11.md
+++ b/releases/notes/1.0.11.md
@@ -1,6 +1,4 @@
-# New functionality
-
-### Hotfix for mapping multiple ports to the same service
+#### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
 ```yaml
@@ -24,12 +22,12 @@ The release notes (as you are reading them now) are generated from the `releases
 Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
 instructions, etc. they will be included here.
 
-### Create startup probes by default
+#### Create startup probes by default
 
 When a project is using livenesProbes, but has no startupProbe defined, we resort to creating a startup probe from the
 default values defined in the `mpyl_config.yml` file. This is done to prevent the project from being marked as
 unhealthy.
 
-### Fix namespace interpolation in the Traefik default hosts
+#### Fix namespace interpolation in the Traefik default hosts
 
 The default hosts for Traefik are now interpolated with the namespace of the project in test/acceptance/production.

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -39,7 +39,7 @@ from ...steps.run import RunResult
 
 
 @dataclass(frozen=True)
-class JiraTicket:
+class JiraTicket:  # pylint: disable = too-many-instance-attributes
     jira_url: str
     ticket_id: str
     ticket_url: str
@@ -229,7 +229,7 @@ class JiraReporter(Reporter):
             self.__move_ticket_forward(ticket)
 
             user_email = results.run_properties.details.user_email
-            if user_email and not ticket.issue_hierarchy < 1:
+            if user_email and ticket.issue_hierarchy < 1:
                 self.__assign_ticket(user_email, ticket)
             return JiraOutcome(success=True)
 

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 
 import requests
 from atlassian import Jira
+from typing_extensions import deprecated
 
 from . import Reporter, ReportOutcome
 from ..formatting.markdown import markdown_for_stage
@@ -226,22 +227,11 @@ class JiraReporter(Reporter):
 
             self.__move_ticket_forward(ticket)
 
-            user_email = results.run_properties.details.user_email
-            if user_email:
-                self.__assign_ticket(user_email, ticket)
             return JiraOutcome(success=True)
 
         except requests.exceptions.HTTPError as exc:
             self._logger.warning(f"Could not handle Jira ticket {self._ticket}: {exc}")
             return JiraOutcome(success=False, exception=exc)
-
-    def __assign_ticket(self, run_user_email: str, ticket: JiraTicket):
-        if ticket.assignee_email is None:
-            jira_user = self._jira.user_find_by_user_string(query=run_user_email)
-            if jira_user:
-                account_id = jira_user.pop().get("accountId")
-                self._logger.info(f"Assigning {ticket.ticket_id} to {account_id}")
-                self._jira.assign_issue(self._ticket, account_id=account_id)
 
     def __move_ticket_forward(self, ticket: JiraTicket):
         transitions = self._jira.get_issue_transitions(self._ticket)

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -44,6 +44,7 @@ class JiraTicket:
     ticket_id: str
     ticket_url: str
     issue_type: str
+    issue_hierarchy: int  # level 1 - Epic, level 0 - Story, level -1 - Sub-task
     summary: str
     description: str
     status_name: str
@@ -68,6 +69,7 @@ class JiraTicket:
             ticket_id=ticket_id,
             ticket_url=ticket_url,
             issue_type=fields["issuetype"]["name"],
+            issue_hierarchy=fields["issuetype"]["hierarchyLevel"],
             summary=fields["summary"],
             status_name=status_name,
             description=fields["description"],
@@ -227,7 +229,7 @@ class JiraReporter(Reporter):
             self.__move_ticket_forward(ticket)
 
             user_email = results.run_properties.details.user_email
-            if user_email and not ticket.user_email:
+            if user_email and not ticket.issue_hierarchy < 1:
                 self.__assign_ticket(user_email, ticket)
             return JiraOutcome(success=True)
 

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -30,7 +30,6 @@ from urllib.parse import urlsplit
 
 import requests
 from atlassian import Jira
-from typing_extensions import deprecated
 
 from . import Reporter, ReportOutcome
 from ..formatting.markdown import markdown_for_stage
@@ -227,11 +226,22 @@ class JiraReporter(Reporter):
 
             self.__move_ticket_forward(ticket)
 
+            user_email = results.run_properties.details.user_email
+            if user_email:
+                self.__assign_ticket(user_email, ticket)
             return JiraOutcome(success=True)
 
         except requests.exceptions.HTTPError as exc:
             self._logger.warning(f"Could not handle Jira ticket {self._ticket}: {exc}")
             return JiraOutcome(success=False, exception=exc)
+
+    def __assign_ticket(self, run_user_email: str, ticket: JiraTicket):
+        if ticket.assignee_email is None:
+            jira_user = self._jira.user_find_by_user_string(query=run_user_email)
+            if jira_user:
+                account_id = jira_user.pop().get("accountId")
+                self._logger.info(f"Assigning {ticket.ticket_id} to {account_id}")
+                self._jira.assign_issue(self._ticket, account_id=account_id)
 
     def __move_ticket_forward(self, ticket: JiraTicket):
         transitions = self._jira.get_issue_transitions(self._ticket)

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 
 import requests
 from atlassian import Jira
+from typing_extensions import deprecated
 
 from . import Reporter, ReportOutcome
 from ..formatting.markdown import markdown_for_stage

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -30,7 +30,6 @@ from urllib.parse import urlsplit
 
 import requests
 from atlassian import Jira
-from typing_extensions import deprecated
 
 from . import Reporter, ReportOutcome
 from ..formatting.markdown import markdown_for_stage

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -227,7 +227,7 @@ class JiraReporter(Reporter):
             self.__move_ticket_forward(ticket)
 
             user_email = results.run_properties.details.user_email
-            if user_email:
+            if user_email and not ticket.user_email:
                 self.__assign_ticket(user_email, ticket)
             return JiraOutcome(success=True)
 


### PR DESCRIPTION
@SamTheisens Sometimes the pipeline can fail with "WARNING: Could not handle Jira ticket EVA-885: You do not have permission to assign issues" and then mark the pipeline as unstable.

Also it's a bit annoying that if you trigger a build on a PR it gets assigned to you, even if it's not your PR

----
### 📕 [TECH-554](https://vandebron.atlassian.net/browse/TECH-554) Do not reassign jira tickets in mpyl pipeline <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [13](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-202/13/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-202.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-202.test.nl/)*, *[sbtservice](https://sbtservice-202.test.nl/)*, *sparkJob*  


[TECH-554]: https://vandebron.atlassian.net/browse/TECH-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ