### PR TITLE
[TECH-470] Prevent titles in release notes from messing up the TOC

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -4,9 +4,7 @@
 
 #### Highlights
 
-# New functionality
-
-### Hotfix for mapping multiple ports to the same service
+#### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
 ```yaml
@@ -24,7 +22,7 @@ deployment:
 ```
 resulted in `8081` being used as servicePort in the treafik rule instead of `4091`.
 
-### Release notes
+#### Release notes
 
 The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project repository.
 Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade
@@ -36,9 +34,7 @@ Details on [Github](https://github.com/Vandebron/mpyl/releases/tag/1.0.11)
 
 #### Highlights
 
-# New functionality
-
-### Support for service monitor
+#### Support for service monitor
 The prometheus [ServiceMonitor](https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/ServiceMonitor/v1@v0.7.0)
 CRD and a corresponding [PrometheusRule](https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/PrometheusRule/v1@v0.7.0)
 are deployed whenever the `metrics` field is defined in `project.yml`

--- a/releases/notes/1.0.10.md
+++ b/releases/notes/1.0.10.md
@@ -1,6 +1,4 @@
-# New functionality
-
-### Support for service monitor
+#### Support for service monitor
 The prometheus [ServiceMonitor](https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/ServiceMonitor/v1@v0.7.0)
 CRD and a corresponding [PrometheusRule](https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/PrometheusRule/v1@v0.7.0)
 are deployed whenever the `metrics` field is defined in `project.yml`

--- a/releases/notes/1.0.11.md
+++ b/releases/notes/1.0.11.md
@@ -1,6 +1,4 @@
-# New functionality
-
-### Hotfix for mapping multiple ports to the same service
+#### Hotfix for mapping multiple ports to the same service
 
 Due to a bug in the mapping of multiple ports to the same service, the following configuration:
 ```yaml
@@ -18,7 +16,7 @@ deployment:
 ```
 resulted in `8081` being used as servicePort in the treafik rule instead of `4091`.
 
-### Release notes
+#### Release notes
 
 The release notes (as you are reading them now) are generated from the `releases/notes` directory in the project repository.
 Whenever a release has changes that require your attention like: new cli commands, new features, breaking changes, upgrade

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from src.mpyl.cli import get_releases, get_latest_release
@@ -15,10 +16,18 @@ class TestDocumentation:
         for release in reverse_chronological:
             combined += f"## MPyL {release}\n\n"
 
-            notes = Path(self.releases_path / "notes" / f"{release}.md")
+            file = f"{release}.md"
+            notes = Path(self.releases_path / "notes" / file)
             if notes.exists():
                 combined += "#### Highlights\n\n"
-                combined += notes.read_text("utf-8") + "\n\n"
+                text = notes.read_text("utf-8")
+
+                # Titles mess up the TOC in the documentation
+                assert not re.match("^# ", text), f"{file} contains a title"
+                assert not re.match("^## ", text), f"{file} contains a subtitle"
+                assert not re.match("^### ", text), f"{file} contains a sub sub title"
+
+                combined += text + "\n\n"
             combined += f"Details on [Github](https://github.com/Vandebron/mpyl/releases/tag/{release})\n\n"
 
         assert_roundtrip(self.releases_path / "README.md", combined)


### PR DESCRIPTION
A little fix for the table of contents in the documentation

branch: fix/TECH-470-clean-release-notes

----
### 📕 [TECH-470](https://vandebron.atlassian.net/browse/TECH-470) Rethink duplicate Jenkinsfiles and runner.py-s <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
Currently we have many very similar Jenkinsfiles, python runners etc in three different repos:

* mpyl repo
* monorepo
* scripting

Figure out a way to centralise these, or to have safeguards to not break them with a breaking change



----

The github action to sync Jenkinsfiles back to the scripting repo could be a good starting point for keeping the repo-runners synced

[https://github.com/Vandebron/Vandebron/blob/master/.github/workflows/push*Jenkinsfile_to_scripting.yml](https://github.com/Vandebron/Vandebron/blob/master/.github/workflows/push_Jenkinsfile_to*scripting.yml) 

Things like repository link, mpyl*config path and run*properties path would need to be configurable/overwriteable through a github action

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-204/3/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-204.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-204.test.nl/)*, *[sbtservice](https://sbtservice-204.test.nl/)*, *sparkJob*  


[TECH-470]: https://vandebron.atlassian.net/browse/TECH-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ