### PR TITLE
[TECH-435] Fix all and dryrun for build jenkins

### DIFF
--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -73,6 +73,7 @@ def main(log: Logger, args: argparse.Namespace):
         pull_main=True,
         verbose=args.verbose,
         all=args.all,
+        dryrun=args.dryrun,
     )
     run_result = run_mpyl(
         run_properties=run_properties,

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -110,7 +110,7 @@ def run_mpyl(
                     properties=run_properties,
                     steps_collection=StepsCollection(logger=logger),
                 )
-                run_result = run_build(run_plan, steps, reporter, cli_parameters.local)
+                run_result = run_build(run_plan, steps, reporter, cli_parameters.dryrun)
             except ValidationError as exc:
                 console.log(
                     f'Schema validation failed {exc.message} at `{".".join(map(str, exc.path))}`'

--- a/src/mpyl/cli/__init__.py
+++ b/src/mpyl/cli/__init__.py
@@ -39,6 +39,7 @@ class MpylCliParameters:
     pull_main: bool = False
     verbose: bool = False
     all: bool = False
+    dryrun: bool = False
 
 
 async def fetch_latest_version() -> Optional[str]:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -356,7 +356,7 @@ def ask_for_input(ctx, _param, value) -> Optional[str]:
     default=False,
 )
 @click.pass_context
-def jenkins(  # pylint: disable=too-many-arguments
+def jenkins(  # pylint: disable=too-many-locals, too-many-arguments
     ctx,
     user,
     password,

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -27,6 +27,8 @@ class JenkinsRunParameters:
     pipeline_parameters: dict
     verbose: bool
     follow: bool
+    dryrun: bool
+    all: bool
     tag: Optional[str] = None
 
 


### PR DESCRIPTION
branch: feature/TECH-435-DRYRUN-JENKINS

----
### 📕 [TECH-435](https://vandebron.atlassian.net/browse/TECH-435) CLI improvements <img src="https://secure.gravatar.com/avatar/22987b802af30079346039ff7c67e6fa?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FES-1.png" width="24" height="24" alt="ewaldschrader@vandebron.nl" /> 
Add support for the following things in the CLI

* do a dry run
* set mpyl version of jenkins run (currently we can only set test version)
* deploy parameters 
* other build parameters?

----

We should be able to set the parameters for Jenkins via the cli like:

```
mpyl build jenkins --argument "run run --dryrun"```


→ this probably doesn’t work with `click` . 

- Define custom argument type with click
- Parse string argument

Another (maybe better) option is to just add a dryrun flag for mpyl cli, and then pass that on to jenkins via the jenkins API:

{noformat}mpyl build jenkins --dryrun
```
```

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-205/4/display/redirect) ✅ Successful, started by _Ewald Schrader_  
🚀 *[cloudfront-service](https://cloudfront-service-205.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-205.test.nl/)*, *[sbtservice](https://sbtservice-205.test.nl/)*, *sparkJob*  


[TECH-435]: https://vandebron.atlassian.net/browse/TECH-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ