### PR TITLE
[TECH-470] Correct pattern for releases.txt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
                             sh "pipenv clean"
                             sh "pipenv install --ignore-pipfile --skip-lock --site-packages --index https://test.pypi.org/simple/ 'mpyl==$CHANGE_ID.*'"
                             sh "pipenv install -d --skip-lock"
+                            sh "pipenv run mpyl version"
                             sh "pipenv run mpyl projects lint --all"
                             sh "pipenv run mpyl health"
                             sh "pipenv run mpyl repo status"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-global-include *.schema.yml *.releases.*.txt
+global-include *.schema.yml releases.txt


### PR DESCRIPTION
Output in build:
```
MPyL 208.2410
Latest public release 1.0.11
```

branch: fix/TECH-470-include-releases-info-in-library


----
### 📕 [TECH-470](https://vandebron.atlassian.net/browse/TECH-470) Rethink duplicate Jenkinsfiles and runner.py-s <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
Currently we have many very similar Jenkinsfiles, python runners etc in three different repos:

* mpyl repo
* monorepo
* scripting

Figure out a way to centralise these, or to have safeguards to not break them with a breaking change



----

The github action to sync Jenkinsfiles back to the scripting repo could be a good starting point for keeping the repo-runners synced

[https://github.com/Vandebron/Vandebron/blob/master/.github/workflows/push*Jenkinsfile_to_scripting.yml](https://github.com/Vandebron/Vandebron/blob/master/.github/workflows/push_Jenkinsfile_to*scripting.yml) 

Things like repository link, mpyl*config path and run*properties path would need to be configurable/overwriteable through a github action

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-208/4/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-208.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-208.test.nl/)*, *[sbtservice](https://sbtservice-208.test.nl/)*, *sparkJob*  


[TECH-470]: https://vandebron.atlassian.net/browse/TECH-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ