### PR TITLE
[TECH-117] Support multiple Docker registries

### DIFF
--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -24,7 +24,7 @@ jira:
   password: !ENV ${MPYL_JIRA_TOKEN_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  default_registry: 'acme.docker.com'
+  defaultRegistry: 'acme.docker.com'
   registries:
     - hostName: 'acme.docker.com'
       userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}

--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -24,15 +24,16 @@ jira:
   password: !ENV ${MPYL_JIRA_TOKEN_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  registry:
-    hostName: 'acme.docker.com'
-    userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
-    password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
-    cache:
-      cacheFromRegistry: false
-      custom:
-        to: 'type=gha,mode=max'
-        from: 'type=gha'
+  default_registry: 'acme.docker.com'
+  registries:
+    - hostName: 'acme.docker.com'
+      userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
+      password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
+      cache:
+        cacheFromRegistry: false
+        custom:
+          to: 'type=gha,mode=max'
+          from: 'type=gha'
   build:
     rootFolder: '.'
     buildTarget: 'builder'

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -384,6 +384,15 @@ class S3Bucket:
 
 
 @dataclass(frozen=True)
+class Docker:
+    host_name: str
+
+    @staticmethod
+    def from_config(values: dict):
+        return Docker(host_name=values["hostName"])
+
+
+@dataclass(frozen=True)
 class Deployment:
     namespace: Optional[str]
     properties: Properties
@@ -423,6 +432,7 @@ class Project:
     path: str
     stages: Stages
     maintainer: list[str]
+    docker: Optional[Docker]
     deployment: Optional[Deployment]
     dependencies: Optional[Dependencies]
 
@@ -502,6 +512,7 @@ class Project:
 
     @staticmethod
     def from_config(values: dict, project_path: Path):
+        docker_config = values.get("docker")
         deployment = values.get("deployment")
         dependencies = values.get("dependencies")
         return Project(
@@ -510,6 +521,7 @@ class Project:
             path=str(project_path),
             stages=Stages.from_config(values.get("stages", {})),
             maintainer=values.get("maintainer", []),
+            docker=Docker.from_config(docker_config) if docker_config else None,
             deployment=Deployment.from_config(deployment) if deployment else None,
             dependencies=Dependencies.from_config(dependencies)
             if dependencies

--- a/src/mpyl/projects/versioning.py
+++ b/src/mpyl/projects/versioning.py
@@ -163,6 +163,13 @@ class ConfigUpgraderOne30(Upgrader):
         index = list(previous_dict).index("cvs")
         cvs = previous_dict.pop("cvs")
         previous_dict.insert(index, "vcs", cvs)
+
+        previous_docker_dict = previous_dict["docker"]
+        default_host_name = copy.deepcopy(previous_docker_dict["registry"]["hostName"])
+        previous_docker_dict.insert(0, "default_registry", default_host_name)
+        previous_docker_dict.insert(1, "registries", [previous_docker_dict["registry"]])
+        previous_docker_dict.pop("registry")
+        previous_dict["docker"] = previous_docker_dict
         return previous_dict
 
 

--- a/src/mpyl/projects/versioning.py
+++ b/src/mpyl/projects/versioning.py
@@ -166,7 +166,7 @@ class ConfigUpgraderOne30(Upgrader):
 
         previous_docker_dict = previous_dict["docker"]
         default_host_name = copy.deepcopy(previous_docker_dict["registry"]["hostName"])
-        previous_docker_dict.insert(0, "default_registry", default_host_name)
+        previous_docker_dict.insert(0, "defaultRegistry", default_host_name)
         previous_docker_dict.insert(1, "registries", [previous_docker_dict["registry"]])
         previous_docker_dict.pop("registry")
         previous_dict["docker"] = previous_docker_dict

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -206,7 +206,7 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      default_registry:
+      defaultRegistry:
         type: string
       registries:
         type: array
@@ -229,7 +229,7 @@ definitions:
         required: [ 'periodSeconds', 'failureThreshold' ]
     required:
       - registries
-      - default_registry
+      - defaultRegistry
     title: Docker
   Build:
     type: object

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -206,8 +206,13 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      registry:
-        "$ref": "#/definitions/Registry"
+      default_registry:
+        type: string
+      registries:
+        type: array
+        minItems: 1
+        items:
+          "$ref": "#/definitions/Registry"
       build:
         "$ref": "#/definitions/Build"
       compose:
@@ -223,7 +228,8 @@ definitions:
             default: 20
         required: [ 'periodSeconds', 'failureThreshold' ]
     required:
-      - registry
+      - registries
+      - default_registry
     title: Docker
   Build:
     type: object

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -100,12 +100,12 @@ properties:
     additionalProperties: false
     properties:
       credentialsId:
-        description: credentialsId for the docker repository
+        description: credentialsId for the docker repository (deprecated)
         examples:
           - exampleRegistry
         type: string
-      registryUrl:
-        description: docker registry url use for the project
+      hostName:
+        description: host name which refers to the docker registry used by this project
         examples:
           - example.azurecr.io
         type: string

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -101,11 +101,12 @@ properties:
     properties:
       credentialsId:
         description: credentialsId for the docker repository (deprecated)
+        deprecationMessage: Use hostName instead
         examples:
           - exampleRegistry
         type: string
       hostName:
-        description: host name which refers to the docker registry used by this project
+        description: host name which refers to the docker registry, as defined in the mpyl config, used by this project
         examples:
           - example.azurecr.io
         type: string

--- a/src/mpyl/steps/build/docker_after_build.py
+++ b/src/mpyl/steps/build/docker_after_build.py
@@ -11,6 +11,7 @@ from ...utilities.docker import (
     docker_registry_path,
     DockerImageSpec,
     push_to_registry,
+    registry_for_project,
 )
 
 
@@ -33,8 +34,9 @@ class AfterBuildDocker(Step):
         self._logger.debug(f"Image to publish: {image_name}")
 
         docker_config = DockerConfig.from_dict(step_input.run_properties.config)
+        docker_registry = registry_for_project(docker_config, step_input.project)
 
-        full_image_path = docker_registry_path(docker_config, image_name)
+        full_image_path = docker_registry_path(docker_registry, image_name)
         artifact = Artifact(
             ArtifactType.DOCKER_IMAGE,
             step_input.run_properties.versioning.revision,
@@ -45,7 +47,7 @@ class AfterBuildDocker(Step):
         if step_input.dry_run:
             return Output(
                 success=True,
-                message=f"Dry run. Not pushing {image_name} to {docker_config.host_name}",
+                message=f"Dry run. Not pushing {image_name} to {docker_registry.host_name}",
                 produced_artifact=artifact,
             )
 

--- a/src/mpyl/steps/build/docker_after_build.py
+++ b/src/mpyl/steps/build/docker_after_build.py
@@ -33,13 +33,14 @@ class AfterBuildDocker(Step):
         image_name = step_input.as_spec(DockerImageSpec).image
         self._logger.debug(f"Image to publish: {image_name}")
 
-        docker_config = DockerConfig.from_dict(step_input.run_properties.config)
+        properties = step_input.run_properties
+        docker_config: DockerConfig = DockerConfig.from_dict(properties.config)
         docker_registry = registry_for_project(docker_config, step_input.project)
 
         full_image_path = docker_registry_path(docker_registry, image_name)
         artifact = Artifact(
             ArtifactType.DOCKER_IMAGE,
-            step_input.run_properties.versioning.revision,
+            properties.versioning.revision,
             self.meta.name,
             DockerImageSpec(image=full_image_path),
         )
@@ -51,7 +52,7 @@ class AfterBuildDocker(Step):
                 produced_artifact=artifact,
             )
 
-        push_to_registry(self._logger, docker_config, image_name)
+        push_to_registry(self._logger, docker_registry, image_name)
 
         return Output(
             success=True,

--- a/src/mpyl/steps/build/dockerbuild.py
+++ b/src/mpyl/steps/build/dockerbuild.py
@@ -32,6 +32,7 @@ from ...utilities.docker import (
     docker_file_path,
     login,
     DockerImageSpec,
+    registry_for_project,
 )
 
 DOCKER_IGNORE_DEFAULT = ["**/target/*", f"**/{BUILD_ARTIFACTS_FOLDER}/*"]
@@ -67,13 +68,14 @@ class BuildDocker(Step):
             # log in to registry, because we may need to pull in a base image
             login(logger=self._logger, docker_config=docker_config)
 
+        docker_registry_config = registry_for_project(docker_config, step_input.project)
         success = build(
             logger=self._logger,
             root_path=docker_config.root_folder,
             file_path=dockerfile,
             image_tag=image_tag,
             target=build_target,
-            docker_config=docker_config,
+            docker_config=docker_registry_config,
         )
         artifact = input_to_artifact(
             ArtifactType.DOCKER_IMAGE, step_input, spec=DockerImageSpec(image=image_tag)

--- a/src/mpyl/steps/build/dockerbuild.py
+++ b/src/mpyl/steps/build/dockerbuild.py
@@ -54,7 +54,9 @@ class BuildDocker(Step):
         )
 
     def execute(self, step_input: Input) -> Output:
-        docker_config = DockerConfig.from_dict(step_input.run_properties.config)
+        docker_config: DockerConfig = DockerConfig.from_dict(
+            step_input.run_properties.config
+        )
         build_target = docker_config.build_target
         if not build_target:
             raise ValueError("docker.buildTarget must be specified")
@@ -66,7 +68,7 @@ class BuildDocker(Step):
 
         if not step_input.dry_run:
             # log in to registry, because we may need to pull in a base image
-            login(logger=self._logger, docker_config=docker_config)
+            login(logger=self._logger, registry_config=docker_config)
 
         docker_registry_config = registry_for_project(docker_config, step_input.project)
         success = build(

--- a/src/mpyl/steps/build/dockerbuild.py
+++ b/src/mpyl/steps/build/dockerbuild.py
@@ -66,18 +66,18 @@ class BuildDocker(Step):
             project=step_input.project, docker_config=docker_config
         )
 
+        docker_registry_config = registry_for_project(docker_config, step_input.project)
         if not step_input.dry_run:
             # log in to registry, because we may need to pull in a base image
-            login(logger=self._logger, registry_config=docker_config)
+            login(logger=self._logger, registry_config=docker_registry_config)
 
-        docker_registry_config = registry_for_project(docker_config, step_input.project)
         success = build(
             logger=self._logger,
             root_path=docker_config.root_folder,
             file_path=dockerfile,
             image_tag=image_tag,
             target=build_target,
-            docker_config=docker_registry_config,
+            registry_config=docker_registry_config,
         )
         artifact = input_to_artifact(
             ArtifactType.DOCKER_IMAGE, step_input, spec=DockerImageSpec(image=image_tag)

--- a/src/mpyl/steps/deploy/dagster.py
+++ b/src/mpyl/steps/deploy/dagster.py
@@ -64,10 +64,9 @@ class DeployDagster(Step):
         """
         Deploys the docker image produced in the build stage as a Dagster user-code-deployment
         """
-        context = cluster_config(
-            step_input.run_properties.target, step_input.run_properties
-        ).context
-        dagster_config = DagsterConfig.from_dict(step_input.run_properties.config)
+        properties = step_input.run_properties
+        context = cluster_config(properties.target, properties).context
+        dagster_config: DagsterConfig = DagsterConfig.from_dict(properties.config)
         dagster_deploy_results = []
 
         config.load_kube_config(context=context)
@@ -95,18 +94,16 @@ class DeployDagster(Step):
             return self.__evaluate_results(dagster_deploy_results)
 
         name_suffix = (
-            f"-{step_input.run_properties.versioning.identifier}"
-            if step_input.run_properties.target == Target.PULL_REQUEST
+            f"-{properties.versioning.identifier}"
+            if properties.target == Target.PULL_REQUEST
             else ""
         )
 
         user_code_deployment = to_user_code_values(
             project=step_input.project,
             name_suffix=name_suffix,
-            run_properties=step_input.run_properties,
-            docker_config=DockerRegistryConfig.from_dict(
-                step_input.run_properties.config
-            ),
+            run_properties=properties,
+            docker_config=DockerRegistryConfig.from_dict(properties.config),
         )
 
         self._logger.debug(f"Deploying user code with values: {user_code_deployment}")

--- a/src/mpyl/steps/deploy/dagster.py
+++ b/src/mpyl/steps/deploy/dagster.py
@@ -23,7 +23,7 @@ from .k8s.resources.dagster import to_user_code_values, to_grpc_server_entry, Co
 from .. import Step, Meta, ArtifactType, Input, Output
 from ...project import Stage, Target
 from ...utilities.dagster import DagsterConfig
-from ...utilities.docker import DockerConfig
+from ...utilities.docker import DockerRegistryConfig
 from ...utilities.helm import convert_to_helm_release_name, shorten_name
 
 
@@ -104,7 +104,9 @@ class DeployDagster(Step):
             project=step_input.project,
             name_suffix=name_suffix,
             run_properties=step_input.run_properties,
-            docker_config=DockerConfig.from_dict(step_input.run_properties.config),
+            docker_config=DockerRegistryConfig.from_dict(
+                step_input.run_properties.config
+            ),
         )
 
         self._logger.debug(f"Deploying user code with values: {user_code_deployment}")

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from .....project import Project, get_env_variables
 from .....steps.models import RunProperties
-from .....utilities.docker import DockerConfig
+from .....utilities.docker import DockerConfig, registry_for_project
 
 
 @dataclass(frozen=True)
@@ -20,6 +20,7 @@ def to_user_code_values(
     run_properties: RunProperties,
     docker_config: DockerConfig,
 ) -> dict:
+    docker_registry = registry_for_project(docker_config, project)
     return {
         "deployments": [
             {
@@ -30,7 +31,7 @@ def to_user_code_values(
                     "pullPolicy": "Always",
                     "imagePullSecrets": [{"name": "bigdataregistry"}],
                     "tag": run_properties.versioning.identifier,
-                    "repository": f"{docker_config.host_name}/{project.name}",
+                    "repository": f"{docker_registry.host_name}/{project.name}",
                 },
                 "includeConfigInLaunchedRuns": {"enabled": True},
                 "name": f"{project.name}{name_suffix}",

--- a/src/mpyl/steps/test/dockertest.py
+++ b/src/mpyl/steps/test/dockertest.py
@@ -78,7 +78,7 @@ class TestDocker(Step):
             file_path=dockerfile,
             image_tag=tag,
             target=test_target,
-            docker_config=docker_registry_config,
+            registry_config=docker_registry_config,
         )
 
         if success:

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -174,7 +174,7 @@ def push_to_registry(
     image = docker.image.inspect(image_name)
     logger.debug(f"Found image {image}")
 
-    login(logger=logger, docker_config=docker_config)
+    login(logger=logger, registry_config=docker_config)
     full_image_path = docker_registry_path(docker_config, image_name)
     docker.image.tag(image, full_image_path)
     docker.image.push(full_image_path, quiet=False)
@@ -288,14 +288,14 @@ def build(
         return False
 
 
-def login(logger: Logger, docker_config: DockerRegistryConfig) -> None:
-    logger.info(f"Logging in with user '{docker_config.user_name}'")
+def login(logger: Logger, registry_config: DockerRegistryConfig) -> None:
+    logger.info(f"Logging in with user '{registry_config.user_name}'")
     docker.login(
-        server=f"https://{docker_config.host_name}",
-        username=docker_config.user_name,
-        password=docker_config.password,
+        server=f"https://{registry_config.host_name}",
+        username=registry_config.user_name,
+        password=registry_config.password,
     )
-    logger.debug(f"Logged in as '{docker_config.user_name}'")
+    logger.debug(f"Logged in as '{registry_config.user_name}'")
 
 
 def create_container(logger: Logger, image_name: str) -> Container:

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -97,7 +97,7 @@ class DockerConfig:
             registries: dict = config["docker"]["registries"]
             build_config: dict = config["docker"]["build"]
             return DockerConfig(
-                default_registry=config["docker"]["default_registry"],
+                default_registry=config["docker"]["defaultRegistry"],
                 registries=[DockerRegistryConfig.from_dict(r) for r in registries],
                 root_folder=build_config["rootFolder"],
                 build_target=build_config.get("buildTarget", None),

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -183,13 +183,13 @@ def push_to_registry(
 def registry_for_project(
     docker_config: DockerConfig, project: Project
 ) -> DockerRegistryConfig:
-    if project.docker:
-        host_name = project.docker.host_name
-    else:
-        host_name = docker_config.default_registry
-    for registry in docker_config.registries:
-        if registry.host_name == host_name:
-            return registry
+    host_name = (
+        project.docker.host_name if project.docker else docker_config.default_registry
+    )
+    registry = next(r for r in docker_config.registries if r.host_name == host_name)
+    if registry:
+        return registry
+
     raise KeyError(f"Docker config has no registry with host name {host_name}")
 
 

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -233,7 +233,7 @@ def build(
     file_path: str,
     image_tag: str,
     target: str,
-    docker_config: Optional[DockerRegistryConfig] = None,
+    registry_config: Optional[DockerRegistryConfig] = None,
 ) -> bool:
     """
     :param logger: the logger
@@ -241,23 +241,23 @@ def build(
     :param file_path: path to the docker file to be built
     :param image_tag: the tag of the image
     :param target: the 'target' within the multi-stage docker image
-    :param docker_config: optional docker config, used what type of cache to use if any
+    :param registry_config: optional docker config, used what type of cache to use if any
     :return: True for success, False for failure
     """
     logger.info(f"Building docker image with {file_path} and target {target}")
 
-    if docker_config and docker_config.cache_from_registry:
-        registry_path = docker_registry_path(docker_config, image_tag)
+    if registry_config and registry_config.cache_from_registry:
+        registry_path = docker_registry_path(registry_config, image_tag)
         cache_from = f"type=registry,ref={registry_path}"
         cache_to = "type=inline"
-    elif docker_config and docker_config.custom_cache_config:
-        cache_from = docker_config.custom_cache_config.cache_from
-        cache_to = docker_config.custom_cache_config.cache_to
+    elif registry_config and registry_config.custom_cache_config:
+        cache_from = registry_config.custom_cache_config.cache_from
+        cache_to = registry_config.custom_cache_config.cache_to
     else:
         cache_from = None
         cache_to = None
 
-    logger.debug(f"Building with cache from: {cache_from} {docker_config}")
+    logger.debug(f"Building with cache from: {cache_from} {registry_config}")
 
     try:
         logs = docker.buildx.build(

--- a/tests/reporting/__init__.py
+++ b/tests/reporting/__init__.py
@@ -94,4 +94,4 @@ def append_results(result: RunResult) -> None:
 
 def __get_other_project():
     stages = Stages(build=None, test=None, deploy=None, postdeploy=None)
-    return Project("test", "Test project", "", stages, [], None, None)
+    return Project("test", "Test project", "", stages, [], None, None, None)

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -107,7 +107,7 @@ class TestKubernetesChart:
     def test_load_docker_config(self):
         yaml_values = parse_config(self.resource_path / DEFAULT_CONFIG_FILE_NAME)
         docker_config = DockerConfig.from_dict(yaml_values)
-        assert docker_config.host_name == "docker_host"
+        assert docker_config.registries[0].host_name == "docker_host"
 
     def test_load_cluster_config(self):
         step_input = Input(

--- a/tests/steps/post_deploy/test_cypress.py
+++ b/tests/steps/post_deploy/test_cypress.py
@@ -23,6 +23,7 @@ class TestCypress:
             path="",
             stages=stages,
             maintainer=[],
+            docker=None,
             deployment=None,
             dependencies=Dependencies.from_config({"postdeploy": []}),
         )

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -115,7 +115,7 @@ class TestSteps:
             properties=test_data.RUN_PROPERTIES,
         )
         stages = Stages(build=None, test=None, deploy=None, postdeploy=None)
-        project = Project("test", "Test project", "", stages, [], None, None)
+        project = Project("test", "Test project", "", stages, [], None, None, None)
         output = steps.execute(stage=Stage.BUILD, project=project).output
         assert not output.success
         assert output.message == "Stage 'build' not defined on project 'test'"
@@ -182,6 +182,7 @@ class TestSteps:
             "",
             stages,
             [],
+            None,
             None,
             Dependencies.from_config({"postdeploy": ["specs/*.js"]}),
         )

--- a/tests/test_resources/mpyl_config.yml
+++ b/tests/test_resources/mpyl_config.yml
@@ -23,7 +23,7 @@ jira:
   password: !ENV ${JIRA_USER_PASSWORD_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  default_registry: !ENV ${DOCKER_HOST_NAME:docker_host}
+  defaultRegistry: !ENV ${DOCKER_HOST_NAME:docker_host}
   registries:
     - hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
       userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}

--- a/tests/test_resources/mpyl_config.yml
+++ b/tests/test_resources/mpyl_config.yml
@@ -23,10 +23,11 @@ jira:
   password: !ENV ${JIRA_USER_PASSWORD_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  registry:
-    hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
-    userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
-    password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
+  default_registry: !ENV ${DOCKER_HOST_NAME:docker_host}
+  registries:
+    - hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
+      userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
+      password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
   build:
     rootFolder: '.'
     buildTarget: 'builder'

--- a/tests/test_resources/test_data.py
+++ b/tests/test_resources/test_data.py
@@ -89,7 +89,7 @@ def get_project_with_stages(stage_config: dict, path: str = "", maintainers=None
     if maintainers is None:
         maintainers = ["Team1", "Team2"]
     stages = Stages.from_config(stage_config)
-    return Project("test", "Test project", path, stages, maintainers, None, None)
+    return Project("test", "Test project", path, stages, maintainers, None, None, None)
 
 
 class MockRepository(Repository):

--- a/tests/test_resources/upgrades/mpyl_config_upgraded.yml
+++ b/tests/test_resources/upgrades/mpyl_config_upgraded.yml
@@ -24,10 +24,11 @@ jira:
   password: !ENV ${JIRA_USER_PASSWORD_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  registry:
-    hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
-    userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
-    password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
+  default_registry: !ENV ${DOCKER_HOST_NAME:docker_host}
+  registries:
+    - hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
+      userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}
+      password: !ENV ${DOCKER_REGISTRY_PSW:docker_password}
   build:
     rootFolder: '.'
     buildTarget: 'builder'

--- a/tests/test_resources/upgrades/mpyl_config_upgraded.yml
+++ b/tests/test_resources/upgrades/mpyl_config_upgraded.yml
@@ -24,7 +24,7 @@ jira:
   password: !ENV ${JIRA_USER_PASSWORD_PSW:jira_password}
   ticketPattern: '[A-Za-z]{2,}-\d+'
 docker:
-  default_registry: !ENV ${DOCKER_HOST_NAME:docker_host}
+  defaultRegistry: !ENV ${DOCKER_HOST_NAME:docker_host}
   registries:
     - hostName: !ENV ${DOCKER_HOST_NAME:docker_host}
       userName: !ENV ${DOCKER_REGISTRY_USR:docker_user}

--- a/tests/utilities/test_docker.py
+++ b/tests/utilities/test_docker.py
@@ -7,6 +7,6 @@ class TestDocker:
     def test_registry_path(self):
         config_values = get_config_values()
         conf = DockerConfig.from_dict(config_values)
-        assert conf.host_name == "docker_host"
-        assert conf.organization is None
-        assert docker_registry_path(conf, "image") == "docker_host/image"
+        assert conf.registries[0].host_name == "docker_host"
+        assert conf.registries[0].organization is None
+        assert docker_registry_path(conf.registries[0], "image") == "docker_host/image"

--- a/tests/utilities/test_docker.py
+++ b/tests/utilities/test_docker.py
@@ -1,12 +1,17 @@
-from src.mpyl.utilities.docker import DockerConfig, docker_registry_path
+from src.mpyl.utilities.docker import (
+    DockerConfig,
+    docker_registry_path,
+    registry_for_project,
+)
 
-from tests.test_resources.test_data import get_config_values
+from tests.test_resources.test_data import get_config_values, get_project
 
 
 class TestDocker:
     def test_registry_path(self):
         config_values = get_config_values()
         conf = DockerConfig.from_dict(config_values)
-        assert conf.registries[0].host_name == "docker_host"
-        assert conf.registries[0].organization is None
-        assert docker_registry_path(conf.registries[0], "image") == "docker_host/image"
+        default_registry = registry_for_project(conf, get_project())
+        assert default_registry.host_name == "docker_host"
+        assert default_registry.organization is None
+        assert docker_registry_path(default_registry, "image") == "docker_host/image"


### PR DESCRIPTION


----
### 📕 [TECH-117](https://vandebron.atlassian.net/browse/TECH-117) Specify external registry per module <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151be71289a54006aa6a62a/27eae4b3-8ab1-4704-9538-ce68c62c341d/24" width="24" height="24" alt="peterrutgers@vandebron.nl" /> 
In order to be able to deploy to different registries based on the projects that we are building.

Needed for NUC deployments.

**How**

* Check how it’s done in MPL
* Improve upon it in MPyL → `Docker After Build` step
* Default config should be bigdataregistry, but we should be able to override that with a config

🏗️ Build [10](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-212/10/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-212.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-212.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-212.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-117]: https://vandebron.atlassian.net/browse/TECH-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ