### PR TITLE
fix/TECH 542 fix linting tag status

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -171,7 +171,7 @@ def __print_status(obj: CliContext):
                 )
             )
 
-        if branch == main_branch and not tag:
+        if branch == main_branch:
             obj.console.log(f"On main branch ({branch}), cannot determine build status")
             return
 

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -1,5 +1,6 @@
 """Commands related to build"""
 import asyncio
+import logging
 import shutil
 import sys
 from pathlib import Path
@@ -28,6 +29,7 @@ from ..build import (
     run_mpyl,
     MpylCliParameters,
     find_build_set,
+    get_build_plan,
 )
 from ..constants import (
     DEFAULT_CONFIG_FILE_NAME,
@@ -195,15 +197,12 @@ def __print_status(obj: CliContext):
         )
         return
 
-    changes = (
-        obj.repo.changes_in_branch_including_local()
-        if ci_branch is None
-        else (
-            obj.repo.changes_in_merge_commit() if tag else obj.repo.changes_in_branch()
-        )
+    result = get_build_plan(
+        logger=logging.getLogger("mpyl"),
+        repo=obj.repo,
+        run_properties=run_properties,
+        cli_parameters=MpylCliParameters(),
     )
-    build_set = find_build_set(obj.repo, changes, False)
-    result = RunResult(run_properties=run_properties, run_plan=build_set)
     if result.run_plan:
         obj.console.print(
             Markdown("**Execution plan:**  \n" + execution_plan_as_markdown(result))

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -28,7 +28,6 @@ from .commands.build.jenkins import JenkinsRunParameters, run_jenkins, get_token
 from ..build import (
     run_mpyl,
     MpylCliParameters,
-    find_build_set,
     get_build_plan,
 )
 from ..constants import (
@@ -41,7 +40,6 @@ from ..reporting.formatting.markdown import (
     execution_plan_as_markdown,
 )
 from ..steps.models import RunProperties
-from ..steps.run import RunResult
 from ..utilities.github import GithubConfig
 from ..utilities.pyaml_env import parse_config
 from ..utilities.repo import Repository, RepoConfig

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -67,7 +67,7 @@ def _check_and_load_projects(
         console.print(
             f"Validated {len(projects)} projects. {len(valid_projects)} valid, {num_invalid} invalid"
         )
-    if num_invalid > 0:
+    if num_invalid > 0 and strict:
         click.get_current_context().exit(1)
     return valid_projects
 


### PR DESCRIPTION
- [x] Only fail linting on strict
- [x] Do not validate git branch setup for tags


----
### 📕 [TECH-542](https://vandebron.atlassian.net/browse/TECH-542) Improve logging for tag builds <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
[p1692788573851919](https://vandebron.slack.com/archives/CGJDDBETU/p1692788573851919) 

I just noticed this in the logs of my tag build:

```
Tag: 20230823-11323 at 6785321f820adb6eab4ebe63b02d1fbf97dcc44e. Base master not present (grafted).                                                                                                                                        
Cannot determine what to build, since this branch has no base. Did you git fetch origin master:refs/remotes/origin/master?
```

I think since it is a tag we don’t need a base right? So maybe a minor improvement could be to skip this check/log for tag builds

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-213/3/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-213.test.nl/)*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-213.test.nl/)*, *[sbtservice](https://sbtservice-213.test.nl/)*, *sparkJob*  


[TECH-542]: https://vandebron.atlassian.net/browse/TECH-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ