### PR TITLE
[TECH-507] Revert the change to the base revision

### DIFF
--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -94,18 +94,13 @@ class Repository:  # pylint: disable=too-many-public-methods
             return None
         return self._repo.active_branch.name
 
-    def _safe_ref_parse(self, branch: str) -> Optional[Commit]:
+    @property
+    def base_revision(self) -> Optional[Commit]:
         try:
-            return self._repo.rev_parse(branch)
+            return self._repo.rev_parse(self.main_origin_branch)
         except BadName as exc:
             logging.debug(f"Does not exist: {exc}")
             return None
-
-    @property
-    def base_revision(self) -> Optional[Commit]:
-        main = self.main_origin_branch
-        local_main = main.replace("origin/", "")
-        return self._safe_ref_parse(local_main) or self._safe_ref_parse(main)
 
     @property
     def get_tag(self) -> Optional[str]:


### PR DESCRIPTION
branch: feature/TECH-507-revert-base-revision-change

----
### 📕 [TECH-507](https://vandebron.atlassian.net/browse/TECH-507) Integrate MPyL with ArgoCD <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
[181](https://github.com/Vandebron/mpyl/issues/181) 

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-230/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-230.test.nl/)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-230.test.nl/)*, *[sbtservice](https://sbtservice-230.test.nl/)*, *sparkJob*  


[TECH-507]: https://vandebron.atlassian.net/browse/TECH-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ