### PR TITLE
feature/TECH 561 gha integration test

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -113,6 +113,8 @@ jobs:
 
   Build_Package:
     runs-on: ubuntu-latest
+    outputs:
+      mpylVersion: ${{ steps.version.outputs.mpylVersion }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -136,6 +138,11 @@ jobs:
         if: github.ref_name != 'main'
         with:
           state: open
+
+      - name: Create Version
+        id: version
+        run: |
+          echo "mpylVersion=${{ steps.findPr.outputs.pr }}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
 
       - name: Build
         if: github.ref_name != 'main'
@@ -161,13 +168,13 @@ jobs:
             New release `${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/). 
             Install with 
             ```
-            pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
+            pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.version.outputs.mpylVersion }}
             ```
           reactions: rocket
           comment_tag: execution
 
       - name: Report deployed pacakge
-        run: echo '### New release! 🚀`${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
+        run: echo '### New release! 🚀`${{ steps.version.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
 
   Integration_Test:
     runs-on: ubuntu-latest
@@ -177,19 +184,12 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Find PR number
-        uses: jwalton/gh-find-current-pr@v1
-        id: findPr
-        if: github.ref_name != 'main'
-        with:
-          state: open
-
       - name: Install MPyL Attempt 1
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }} || true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
 
       - name: Install MPyL Attempt 2
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
 
       - name: Show files
         run: ls -latr

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -180,9 +180,12 @@ jobs:
       - name: Report deployed pacakge
         run: echo '### New release! 🚀`${{ steps.version.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
 
-      - name: Ensure package is in pypi cache
+      - name: Ensure package is in pypi cache, attempt 1
         continue-on-error: true
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+
+      - name: Ensure package is in pypi cache, attempt 2
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
 
 
   Integration_Test_PR:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -206,6 +206,15 @@ jobs:
       - name: Repo status
         run: mpyl repo status
 
+      - name: Check mpyl health
+        run: mpyl health --ci
+
+      - name: Lint projects
+        run: mpyl projects lint
+
+      - name: Validate upgrade status
+        run: mpyl projects upgrade
+
       - name: Build status
         run: mpyl build status
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -113,7 +113,6 @@ jobs:
 
   Build_Package:
     runs-on: ubuntu-latest
-    needs: [Lint, TypeCheck, Test]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -172,7 +171,7 @@ jobs:
 
   Integration_Test:
     runs-on: ubuntu-latest
-    needs: [ Build_Package ]
+    needs: [ Lint, TypeCheck, Test, Build_Package ]
     steps:
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -169,3 +169,43 @@ jobs:
 
       - name: Report deployed pacakge
         run: echo '### New release! 🚀`${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
+
+  Integration_Test:
+    runs-on: ubuntu-latest
+    needs: [ Build_Package ]
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        if: github.ref_name != 'main'
+        with:
+          state: open
+
+      - name: Install MPyL 1
+        continue-on-error: true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
+
+      - name: Install MPyL 2
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
+
+      - name: Show files
+        run: ls -latr
+
+      - name: Show path
+        run: pwd
+
+      - name: Clean workspace
+        run: rm -rf *
+
+      - name: Initialize repo
+        run: mpyl repo -c mpyl_config.example.yml init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
+
+      - name: Repo status
+        run: mpyl repo status
+
+      - name: Build status
+        run: mpyl build status

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -114,7 +114,7 @@ jobs:
           number: ${{ steps.findPr.outputs.pr }}
           path: code-coverage-results.md
 
-  Build_Package:
+  Build_And_Upload:
     name: 🏗️ Build package
     runs-on: ubuntu-latest
     outputs:
@@ -143,6 +143,11 @@ jobs:
         with:
           state: open
 
+      - name: Publish PR Number
+        id: pr
+        run: |
+          echo "pr=${{ steps.findPr.outputs.pr }}" >> "$GITHUB_OUTPUT"
+
       - name: Create Version
         id: version
         run: |
@@ -163,23 +168,6 @@ jobs:
           TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
         run: pipenv run publish
 
-      - name: Comment Published package
-        uses: thollander/actions-comment-pull-request@v2
-        if: success()
-        with:
-          pr_number: ${{ steps.findPr.outputs.pr }}
-          message: |
-            New release `${{ steps.findPr.outputs.pr }}.${{ github.run_number }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/). 
-            Install with 
-            ```
-            pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.version.outputs.mpylVersion }}
-            ```
-          reactions: rocket
-          comment_tag: execution
-
-      - name: Report deployed pacakge
-        run: echo '### New release! 🚀`${{ steps.version.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
-
       - name: Ensure package is in pypi cache, attempt 1
         continue-on-error: true
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.version.outputs.mpylVersion }} || true
@@ -189,9 +177,9 @@ jobs:
 
 
   Integration_Test_PR:
-    name: Test PR v${{ needs.Build_Package.outputs.mpylVersion }}
+    name: Test PR
     runs-on: ubuntu-latest
-    needs: [ Build_Package ]
+    needs: [ Build_And_Upload ]
     env:
       MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:
@@ -201,7 +189,7 @@ jobs:
 
       - name: Install MPyL
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_And_Upload.outputs.mpylVersion }}
 
       - name: Initialize repo
         run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
@@ -231,9 +219,9 @@ jobs:
         run: mpyl build run
 
   Integration_Test_Tag:
-    name: Test tag v${{ needs.Build_Package.outputs.mpylVersion }}
+    name: Test tag
     runs-on: ubuntu-latest
-    needs: [ Build_Package ]
+    needs: [ Build_And_Upload ]
     env:
       MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:
@@ -243,7 +231,7 @@ jobs:
 
       - name: Install MPyL
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_And_Upload.outputs.mpylVersion }}
 
       - name: Initialize repo
         run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
@@ -276,19 +264,44 @@ jobs:
         run: git merge --no-ff -m "Merge PR ${{ github.ref }}" ${{ github.ref }}
 
       - name: Tag merge
-        run: git tag -a v${{ needs.Build_Package.outputs.mpylVersion }} -m "Tagging v${{ needs.Build_Package.outputs.mpylVersion }}"
+        run: git tag -a v${{ needs.Build_And_Upload.outputs.mpylVersion }} -m "Tagging v${{ needs.Build_And_Upload.outputs.mpylVersion }}"
 
       - name: Repo status after merge
         env:
-          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
+          TAG_NAME: v${{ needs.Build_And_Upload.outputs.mpylVersion }}
         run: mpyl repo status
 
       - name: Show build status
         env:
-          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
+          TAG_NAME: v${{ needs.Build_And_Upload.outputs.mpylVersion }}
         run: mpyl build status
 
       - name: Run tag build
         env:
-          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
+          TAG_NAME: v${{ needs.Build_And_Upload.outputs.mpylVersion }}
         run: mpyl build run
+
+  Build_Package:
+    # TODO: Rename this step and update the merge rule to match
+    # name: Publish v${{ needs.Build_And_Upload.outputs.mpylVersion }}
+    runs-on: ubuntu-latest
+    needs: [ Build_And_Upload, Lint, TypeCheck, Test, Integration_Test_PR, Integration_Test_Tag ]
+    env:
+      MPYL_CONFIG_PATH: mpyl_config.example.yml
+    steps:
+      - name: Comment Published package
+        uses: thollander/actions-comment-pull-request@v2
+        if: success()
+        with:
+          pr_number: ${{ needs.Build_And_Upload.outputs.mpylVersion }}
+          message: |
+            New release `${{ needs.Build_And_Upload.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/). 
+            Install with 
+            ```
+            pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_And_Upload.outputs.mpylVersion }}
+            ```
+          reactions: rocket
+          comment_tag: execution
+
+      - name: Report deployed pacakge
+        run: echo '### New release! 🚀`${{ steps.version.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -182,10 +182,10 @@ jobs:
 
       - name: Ensure package is in pypi cache, attempt 1
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.version.outputs.mpylVersion }} || true
 
       - name: Ensure package is in pypi cache, attempt 2
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.version.outputs.mpylVersion }}
 
 
   Integration_Test_PR:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -205,7 +205,7 @@ jobs:
         run: mpyl repo -c mpyl_config.example.yml init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
 
       - name: Repo status
-        run: mpyl repo status
+        run: mpyl repo -c mpyl_config.example.yml status
 
       - name: Build status
-        run: mpyl build status
+        run: mpyl build -c mpyl_config.example.yml status

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -206,3 +206,12 @@ jobs:
 
       - name: Build status
         run: mpyl build -c mpyl_config.example.yml status
+
+      - name: Force change
+        run: echo "To force a change " >> tests/projects/service/change.txt
+
+      - name: Build status with change
+        run: mpyl build -c mpyl_config.example.yml status
+
+      - name: Build run
+        run: mpyl build -c mpyl_config.example.yml run

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -275,7 +275,17 @@ jobs:
       - name: Tag merge
         run: git tag -a v${{ needs.Build_Package.outputs.mpylVersion }} -m "Tagging v${{ needs.Build_Package.outputs.mpylVersion }}"
 
+      - name: Repo status after merge
+        env:
+          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
+        run: mpyl repo status
+
       - name: Show build status
         env:
           TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
         run: mpyl build status
+
+      - name: Run tag build
+        env:
+          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
+        run: mpyl build run

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   Lint:
+    name: 🧽Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +34,7 @@ jobs:
         run: pipenv run lint-test
 
   TypeCheck:
+    name: 🧐Check types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
         run: pipenv run check-types-test
 
   Test:
+    name: 🧪Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -112,6 +115,7 @@ jobs:
           path: code-coverage-results.md
 
   Build_Package:
+    name: 🏗️Build package
     runs-on: ubuntu-latest
     outputs:
       mpylVersion: ${{ steps.version.outputs.mpylVersion }}
@@ -148,7 +152,7 @@ jobs:
         if: github.ref_name != 'main'
         env:
           PIPENV_DONT_LOAD_ENV: true
-          MPYL_VERSION: "${{ steps.findPr.outputs.pr }}.${{ github.run_number }}"
+          MPYL_VERSION: ${{ steps.version.outputs.mpylVersion }}
         run: pipenv run build
 
       - name: Publish package
@@ -181,9 +185,43 @@ jobs:
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
 
 
-  Integration_Test:
+  Integration_Test_PR:
+    name: Build PR v${{ needs.Build_Package.outputs.mpylVersion }}
     runs-on: ubuntu-latest
-    needs: [ Lint, TypeCheck, Test, Build_Package ]
+    needs: [ Build_Package ]
+    env:
+      MPYL_CONFIG_PATH: mpyl_config.example.yml
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install MPyL
+        continue-on-error: true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+
+      - name: Initialize repo
+        run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
+
+      - name: Repo status
+        run: mpyl repo status
+
+      - name: Build status
+        run: mpyl build status
+
+      - name: Force change
+        run: echo "To force a change " >> tests/projects/service/change.txt
+
+      - name: Build status with change
+        run: mpyl build status
+
+      - name: Build run
+        run: mpyl build run
+
+  Integration_Test_Tag:
+    name: Build Tag v${{ needs.Build_Package.outputs.mpylVersion }}
+    runs-on: ubuntu-latest
+    needs: [ Build_Package ]
     env:
       MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -185,18 +185,15 @@ jobs:
         with:
           state: open
 
-      - name: Install MPyL 1
+      - name: Install MPyL Attempt 1
         continue-on-error: true
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
 
-      - name: Install MPyL 2
+      - name: Install MPyL Attempt 2
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
 
       - name: Show files
         run: ls -latr
-
-      - name: Show path
-        run: pwd
 
       - name: Clean workspace
         run: rm -rf *

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -179,6 +179,8 @@ jobs:
   Integration_Test:
     runs-on: ubuntu-latest
     needs: [ Lint, TypeCheck, Test, Build_Package ]
+    env:
+      MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:
       - uses: actions/setup-python@v4
         with:
@@ -198,19 +200,19 @@ jobs:
         run: rm -rf *
 
       - name: Initialize repo
-        run: mpyl repo -c mpyl_config.example.yml init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
+        run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
 
       - name: Repo status
-        run: mpyl repo -c mpyl_config.example.yml status
+        run: mpyl repo status
 
       - name: Build status
-        run: mpyl build -c mpyl_config.example.yml status
+        run: mpyl build status
 
       - name: Force change
         run: echo "To force a change " >> tests/projects/service/change.txt
 
       - name: Build status with change
-        run: mpyl build -c mpyl_config.example.yml status
+        run: mpyl build status
 
       - name: Build run
-        run: mpyl build -c mpyl_config.example.yml run
+        run: mpyl build run

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -176,6 +176,11 @@ jobs:
       - name: Report deployed pacakge
         run: echo '### New release! 🚀`${{ steps.version.outputs.mpylVersion }}` deployed at [Test Pypi](https://test.pypi.org/project/mpyl/)' >> $GITHUB_STEP_SUMMARY
 
+      - name: Ensure package is in pypi cache
+        continue-on-error: true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+
+
   Integration_Test:
     runs-on: ubuntu-latest
     needs: [ Lint, TypeCheck, Test, Build_Package ]
@@ -186,18 +191,9 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install MPyL Attempt 1
+      - name: Install MPyL
         continue-on-error: true
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
-
-      - name: Install MPyL Attempt 2
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
-
-      - name: Show files
-        run: ls -latr
-
-      - name: Clean workspace
-        run: rm -rf *
 
       - name: Initialize repo
         run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   Lint:
-    name: 🧽Lint
+    name: 🧽 Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
         run: pipenv run lint-test
 
   TypeCheck:
-    name: 🧐Check types
+    name: 🧐 Check types
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
         run: pipenv run check-types-test
 
   Test:
-    name: 🧪Test
+    name: 🧪 Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
           path: code-coverage-results.md
 
   Build_Package:
-    name: 🏗️Build package
+    name: 🏗️ Build package
     runs-on: ubuntu-latest
     outputs:
       mpylVersion: ${{ steps.version.outputs.mpylVersion }}
@@ -186,7 +186,7 @@ jobs:
 
 
   Integration_Test_PR:
-    name: Build PR v${{ needs.Build_Package.outputs.mpylVersion }}
+    name: Test PR v${{ needs.Build_Package.outputs.mpylVersion }}
     runs-on: ubuntu-latest
     needs: [ Build_Package ]
     env:
@@ -198,7 +198,7 @@ jobs:
 
       - name: Install MPyL
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
 
       - name: Initialize repo
         run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
@@ -219,7 +219,7 @@ jobs:
         run: mpyl build run
 
   Integration_Test_Tag:
-    name: Build Tag v${{ needs.Build_Package.outputs.mpylVersion }}
+    name: Test tag v${{ needs.Build_Package.outputs.mpylVersion }}
     runs-on: ubuntu-latest
     needs: [ Build_Package ]
     env:
@@ -231,10 +231,14 @@ jobs:
 
       - name: Install MPyL
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }} || true
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ needs.Build_Package.outputs.mpylVersion }}
 
       - name: Initialize repo
         run: mpyl repo init -b ${{ github.ref }} -u https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git -p
+
+      - name: Get head revision
+        id: headRevision
+        run: echo "headRevision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Repo status
         run: mpyl repo status
@@ -243,10 +247,26 @@ jobs:
         run: mpyl build status
 
       - name: Force change
-        run: echo "To force a change " >> tests/projects/service/change.txt
+        run: |
+          echo "To force a change " >> tests/projects/service/change.txt
+          git add tests/projects/service/change.txt
 
-      - name: Build status with change
+      - name: Commit the change
+        run: |
+          git config --global user.email "somebody@somewhere.com"
+          git config --global user.name "Some Person"
+          git commit -a -m "A random change"
+
+      - name: Switch to main
+        run: git checkout -b main $${{ steps.headRevision.outputs.headRevision }}
+
+      - name: Merge branch
+        run: git merge --no-ff -m "Merge PR ${{ github.ref }}" ${{ github.ref }}
+
+      - name: Tag merge
+        run: git tag -a v${{ needs.Build_Package.outputs.mpylVersion }} -m "Tagging v${{ needs.Build_Package.outputs.mpylVersion }}"
+
+      - name: Show build status
+        env:
+          TAG_NAME: v${{ needs.Build_Package.outputs.mpylVersion }}
         run: mpyl build status
-
-      - name: Build run
-        run: mpyl build run

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -258,7 +258,7 @@ jobs:
           git commit -a -m "A random change"
 
       - name: Switch to main
-        run: git checkout -b main $${{ steps.headRevision.outputs.headRevision }}
+        run: git checkout -b main ${{ steps.headRevision.outputs.headRevision }}
 
       - name: Merge branch
         run: git merge --no-ff -m "Merge PR ${{ github.ref }}" ${{ github.ref }}

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Install MPyL Attempt 1
         continue-on-error: true
-        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}
+        run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }} || true
 
       - name: Install MPyL Attempt 2
         run: pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mpyl==${{ steps.findPr.outputs.pr }}.${{ github.run_number }}

--- a/Pipfile
+++ b/Pipfile
@@ -38,7 +38,7 @@ dagster = "==1.2.6"
 pylint = "==2.17.0"
 pytest = "==7.2.1"
 pytest-xdist = "==3.3.1"
-pdoc = "==13.1.1"
+pdoc = "==14.0.0"
 sqlalchemy = "<2.0.0" # forced downgrade https://github.com/dagster-io/dagster/discussions/11881
 coverage = "==7.2.2"
 'black[d]' = "==23.3.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e47e88a46b0608669ac80bb02f2ecced9c90e7502edd2fe12c05c9fe3e7dd8c2"
+            "sha256": "7eba72870b0c3454eda702c8e86945f565b4483284aa5a4ed974d2676853a330"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1103,11 +1103,11 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:53e95c826bf800c4c465f50093a8c4ff091c7327023b10bfaff40cf1ef170eaa",
-                "sha256:ce54f419dfae71f4bdba69ebe65bf7f0a93fe71bc009ad3a010aacc3eebad537"
+                "sha256:3aad25d31284266bcfcfd1fd8a743f63282305a364b8d0948a43bd606acc652f",
+                "sha256:6cfc30d051ebabb73a5fa246efdcc14c8fbebbd0330f8984ac3bb6d9edd2ad03"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.6.2"
+            "version": "==1.6.3"
         },
         "wrapt": {
             "hashes": [
@@ -1437,9 +1437,7 @@
             "version": "==2.2.1"
         },
         "black": {
-            "extras": [
-                "d"
-            ],
+            "extras": [],
             "hashes": [
                 "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5",
                 "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915",
@@ -2258,11 +2256,11 @@
         },
         "pdoc": {
             "hashes": [
-                "sha256:2b8e341b1882ed8217e95c1f3f1f11d34f9ef93a5796287590162e2035296815",
-                "sha256:9025c6cd2448b18662e88eacf84c6eb050dcbdc8ee5259aee5e40a1c2b417840"
+                "sha256:4514041ff5da33f1adbc700002a661600fc13a9adadef317bc6ae8be9e61154b",
+                "sha256:ad6c16c949e5dd8b30effc5398aedb5779ffe8ab94be91ce2cddc320e8127900"
             ],
             "index": "pypi",
-            "version": "==13.1.1"
+            "version": "==14.0.0"
         },
         "pendulum": {
             "hashes": [

--- a/README-usage.md
+++ b/README-usage.md
@@ -143,6 +143,65 @@ The [schema](https://vandebron.github.io/mpyl/schema/project.schema.yml) for `pr
 documentation and
 can be used to enable on-the-fly validation and auto-completion in your IDE.
 
+## ..setting up a CI-CD flow
+
+MPyL is not a taskrunner nor is it a tool to define and run CI-CD flows. It does however provide a building blocks that can
+easily be plugged into any existing CI-CD platform.
+
+### Github actions
+
+Github actions are a natural fit for MPyL. To build a pull request, you can use the following workflow:
+```yaml
+name: Build pull request
+on:
+  push:
+    branches-ignore: [ 'main' ]
+
+jobs:
+  Build_PR:
+    name: Build and deploy the pull request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install MPyL
+        run: pip install 'mpyl==<latest_version>'
+
+      - name: Initialize repo
+        run: mpyl repo init --branch ${{ github.ref }} --url https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git --pristine
+
+      - name: Print execution plan
+        run: mpyl build status
+
+      - name: Build run
+        run: mpyl build run
+```
+The `--pristine` flag in the `mpyl repo init` command will clone the repository into the current *empty* workspace, using
+```shell
+git clone --shallow-exclude main --single-branch --branch <branch_name> https://github.com/<org>/<repo>.git
+```
+This will result in a shallow clone of the repository, containing only the files that are relevant for the current
+pull request.
+
+### Dagster
+Although [dagster](https://dagster.io/)'s primary focus is data processing and lineage, it can be used as a runner for MPyL.
+It provides a nice UI to inspect the flow and logs. It supports concurrent execution of steps in a natural way.
+These features make it a convenient runner for local development and debugging.
+
+<details>
+  <summary>Dagster flow runner</summary>
+```python
+.. include:: mpyl-dagster-example.py
+```
+</details>
+
+It can be started from the command line with `dagit --workspace workspace.yml`.
+
+![Dagster flow](documentation_images/dagster-flow-min.png)
+![Dagster run](documentation_images/dagster-run-min.png)
+
 ## ..report the outcome of a pipeline run
 
 MPyL comes with built-in reporters for *Github*, *Jira* and *Slack*. See `mpyl.reporting.targets` how to configure
@@ -181,22 +240,3 @@ upgrades, with a real postgres database:
 
 Note: make sure to define a reliable `healthcheck` to prevent your tests from being run before the database is
 fully up and running.
-
-## ..create a custom CI-CD flow
-
-MPyL is not a task runner or a tool to define CI-CD flows. It does however provide a building blocks that can
-easily be plugged into your own CI-CD flow.
-Here's an example using [Dagster](https://dagster.io/) as a runner
-
-<details>
-  <summary>Dagster flow runner</summary>
-```python
-.. include:: mpyl-dagster-example.py
-```
-</details>
-
-It can be started from the command line with `dagit --workspace workspace.yml`.
-
-![Dagster flow](documentation_images/dagster-flow-min.png)
-![Dagster run](documentation_images/dagster-run-min.png)
-

--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -67,7 +67,7 @@ whiteLists:
     - name: 'K8s-Test'
       values: [ '1.2.3.0', '1.2.3.1' ]
 kubernetes:
-  deployAction: HelmDeploy
+  deployAction: KubectlManifest
   rancher:
     cluster:
       test:

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -32,14 +32,6 @@ def get_build_plan(
 ) -> RunResult:
     branch = repo.get_branch or run_properties.versioning.branch
     if branch:
-        if repo.base_revision:
-            logger.info(
-                f"Branch `{repo.main_branch}` already present locally. Skipping pull."
-            )
-        else:
-            logger.info(f"Pulling `{repo.main_branch}` from {repo.remote_url}")
-            pull_result = repo.fetch_main_branch()
-            logger.info(f"Pulled `{pull_result[0].remote_ref_path.strip()}` to local")
         changes = (
             repo.changes_in_branch_including_local()
             if cli_parameters.local

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -30,18 +30,18 @@ def get_build_plan(
     run_properties: RunProperties,
     cli_parameters: MpylCliParameters,
 ) -> RunResult:
-    branch = repo.get_branch or run_properties.versioning.branch
-    if branch:
+    tag = run_properties.versioning.tag
+    if tag:
+        changes = (
+            repo.changes_in_tagged_commit(tag)
+            if tag
+            else repo.changes_in_merge_commit()
+        )
+    else:
         changes = (
             repo.changes_in_branch_including_local()
             if cli_parameters.local
             else repo.changes_in_branch()
-        )
-    else:
-        changes = (
-            repo.changes_in_tagged_commit(run_properties.versioning.tag)
-            if run_properties.versioning.tag
-            else repo.changes_in_merge_commit()
         )
     logger.debug(f"Changes: {changes}")
 

--- a/src/mpyl/cli/__init__.py
+++ b/src/mpyl/cli/__init__.py
@@ -34,7 +34,7 @@ class CliContext:
 
 @dataclass(frozen=True)
 class MpylCliParameters:
-    local: bool = True
+    local: bool = False
     tag: Optional[str] = None
     pull_main: bool = False
     verbose: bool = False

--- a/src/mpyl/cli/__init__.py
+++ b/src/mpyl/cli/__init__.py
@@ -34,7 +34,7 @@ class CliContext:
 
 @dataclass(frozen=True)
 class MpylCliParameters:
-    local: bool = False
+    local: bool = True
     tag: Optional[str] = None
     pull_main: bool = False
     verbose: bool = False

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -136,7 +136,10 @@ def run(obj: CliContext, ci, all_, tag):  # pylint: disable=invalid-name
             obj.config, obj.repo.get_sha, obj.repo.get_branch, tag
         )
     )
-    run_mpyl(run_properties=run_properties, cli_parameters=parameters, reporter=None)
+    result = run_mpyl(
+        run_properties=run_properties, cli_parameters=parameters, reporter=None
+    )
+    sys.exit(0 if result.is_success else 1)
 
 
 @build.command(help="The status of the current local branch from MPyL's perspective")

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -199,7 +199,7 @@ def __print_status(obj: CliContext):
         logger=logging.getLogger("mpyl"),
         repo=obj.repo,
         run_properties=run_properties,
-        cli_parameters=MpylCliParameters(),
+        cli_parameters=MpylCliParameters(local=sys.stdout.isatty()),
     )
     if result.run_plan:
         console.print(

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -192,16 +192,6 @@ def __print_status(obj: CliContext):
     )
     console.print(Markdown(f"Base `{main_branch}` {base_revision_specification}"))
 
-    if not base_revision and not tag:
-        fetch = f"`git fetch origin {main_branch}:refs/remotes/origin/{main_branch}`"
-        console.print(
-            Markdown(
-                f"Cannot determine what to build, since this branch has no base. "
-                f"Did you {fetch}?"
-            )
-        )
-        return
-
     result = get_build_plan(
         logger=logging.getLogger("mpyl"),
         repo=obj.repo,

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -129,6 +129,15 @@ def run(obj: CliContext, ci, all_, tag):  # pylint: disable=invalid-name
     )
     obj.console.log(parameters)
 
+    if tag and not obj.repo.fit_for_tag_build(tag):
+        obj.console.print(
+            Markdown(
+                f"Current state of repo is not fit for building tag `{tag}`."
+                f"Validate the status of the repo by running `mpyl repo status`."
+            )
+        )
+        sys.exit(1)
+
     run_properties = (
         RunProperties.from_configuration(obj.run_properties, obj.config, tag)
         if ci

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -180,12 +180,17 @@ def __print_status(obj: CliContext):
     version = run_properties.versioning
     revision = version.revision or obj.repo.get_sha
     base_revision = obj.repo.base_revision
+    base_revision_specification = (
+        f"at `{base_revision}`"
+        if base_revision
+        else f"not present. Earliest revision: `{obj.repo.root_commit_hex}` (grafted)."
+    )
     console.print(
         Markdown(
             f"**{'Tag' if tag else 'Branch'}:** `{branch or version.tag}` at `{revision}`. "
-            f"Base `{main_branch}` {f'at `{base_revision}`' if base_revision else 'not present (grafted).'}"
         )
     )
+    console.print(Markdown(f"Base `{main_branch}` {base_revision_specification}"))
 
     if not base_revision and not tag:
         fetch = f"`git fetch origin {main_branch}:refs/remotes/origin/{main_branch}`"

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -192,17 +192,17 @@ def __print_status(obj: CliContext):
     version = run_properties.versioning
     revision = version.revision or obj.repo.get_sha
     base_revision = obj.repo.base_revision
-    base_revision_specification = (
-        f"at `{base_revision}`"
-        if base_revision
-        else f"not present. Earliest revision: `{obj.repo.root_commit_hex}` (grafted)."
-    )
-    console.print(
-        Markdown(
-            f"**{'Tag' if tag else 'Branch'}:** `{branch or version.tag}` at `{revision}`. "
+    if tag:
+        console.print(Markdown(f"**Tag:** `{version.tag}` at `{revision}`. "))
+    else:
+        base_revision_specification = (
+            f"at `{base_revision}`"
+            if base_revision
+            else f"not present. Earliest revision: `{obj.repo.root_commit_hex}` (grafted)."
         )
-    )
-    console.print(Markdown(f"Base `{main_branch}` {base_revision_specification}"))
+        console.print(
+            Markdown(f"**Branch:** `{branch}`. Base {base_revision_specification}. ")
+        )
 
     result = get_build_plan(
         logger=logging.getLogger("mpyl"),

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -158,14 +158,14 @@ def status(obj: CliContext):
 
 def __print_status(obj: CliContext):
     run_properties = RunProperties.from_configuration(obj.run_properties, obj.config)
-    obj.console.print(f"MPyL log level is set to {run_properties.console.log_level}")
+    console = obj.console
+    console.print(f"MPyL log level is set to {run_properties.console.log_level}")
 
     branch = obj.repo.get_branch
     main_branch = obj.repo.main_branch
-    tag = obj.repo.get_tag if not branch else None
-    console = obj.console
+    tag = run_properties.versioning.tag
 
-    if not tag:
+    if tag is None:
         if run_properties.versioning.branch and not obj.repo.get_branch:
             console.print("Current branch is detached.")
         else:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -107,7 +107,7 @@ def build(ctx, config, properties, verbose):
 @click.option(
     "--ci",
     is_flag=True,
-    help="Run as CI build instead of local. Ignores unversioned changes.",
+    help="Run as CI build instead of local. Ignores untracked changes.",
 )
 @click.option(
     "--all",

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -155,18 +155,18 @@ def status(obj: CliContext):
 
 def __print_status(obj: CliContext):
     run_properties = RunProperties.from_configuration(obj.run_properties, obj.config)
-    ci_branch = run_properties.versioning.branch
     obj.console.print(f"MPyL log level is set to {run_properties.console.log_level}")
 
     branch = obj.repo.get_branch
     main_branch = obj.repo.main_branch
     tag = obj.repo.get_tag if not branch else None
+    console = obj.console
 
     if not tag:
-        if ci_branch and not obj.repo.get_branch:
-            obj.console.print("Current branch is detached.")
+        if run_properties.versioning.branch and not obj.repo.get_branch:
+            console.print("Current branch is detached.")
         else:
-            obj.console.log(
+            console.log(
                 Markdown(
                     f"Branch not specified at `build.versioning.branch` in _{DEFAULT_RUN_PROPERTIES_FILE_NAME}_, "
                     f"falling back to git: _{obj.repo.get_branch}_"
@@ -174,13 +174,13 @@ def __print_status(obj: CliContext):
             )
 
         if branch == main_branch:
-            obj.console.log(f"On main branch ({branch}), cannot determine build status")
+            console.log(f"On main branch ({branch}), cannot determine build status")
             return
 
     version = run_properties.versioning
     revision = version.revision or obj.repo.get_sha
     base_revision = obj.repo.base_revision
-    obj.console.print(
+    console.print(
         Markdown(
             f"**{'Tag' if tag else 'Branch'}:** `{branch or version.tag}` at `{revision}`. "
             f"Base `{main_branch}` {f'at `{base_revision}`' if base_revision else 'not present (grafted).'}"
@@ -189,7 +189,7 @@ def __print_status(obj: CliContext):
 
     if not base_revision and not tag:
         fetch = f"`git fetch origin {main_branch}:refs/remotes/origin/{main_branch}`"
-        obj.console.print(
+        console.print(
             Markdown(
                 f"Cannot determine what to build, since this branch has no base. "
                 f"Did you {fetch}?"
@@ -204,11 +204,11 @@ def __print_status(obj: CliContext):
         cli_parameters=MpylCliParameters(),
     )
     if result.run_plan:
-        obj.console.print(
+        console.print(
             Markdown("**Execution plan:**  \n" + execution_plan_as_markdown(result))
         )
     else:
-        obj.console.print("No changes detected, nothing to do.")
+        console.print("No changes detected, nothing to do.")
 
 
 class Pipeline(ParamType):

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -116,21 +116,6 @@ def status(obj: CliContext):
         )
 
 
-@repository.command(help="Return repository credentials")
-@click.pass_obj
-def credentials(obj: CliContext):
-    repo_config = RepoConfig.from_config(obj.config).repo_credentials
-    if "username" in sys.argv[1].lower():
-        print(repo_config.username)
-        sys.exit()
-
-    if "password" in sys.argv[1].lower():
-        print(repo_config.password)
-        sys.exit()
-
-    sys.exit(1)
-
-
 @repository.command(help="Initialize the repository for a build run")
 @click.option("--url", "-u", type=click.STRING, help="URL to the remote repository")
 @click.option("--pull", "-pr", type=click.INT, help="PR number to fetch")

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -144,10 +144,10 @@ def init(obj: RepoContext, url: str, pull: int, branch: str, pristine: bool):
 
     console.log("Preparing repository for a new run...")
 
-    with Repository(
-        config=RepoConfig.from_config(parse_config(obj.config))
-    ) if pristine else Repository.clone_from_branch(
+    with Repository.clone_from_branch(
         branch.replace("refs/heads/", ""), url, "main", obj.config, Path(".")
+    ) if pristine else Repository(
+        config=RepoConfig.from_config(parse_config(obj.config))
     ) as repo:
         config = parse_config(obj.config)
         if not repo.remote_url:

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -122,13 +122,6 @@ def status(obj: RepoContext):
             )
 
 
-def _get_pristine_repo(obj: RepoContext, url: str, branch: str):
-    repo = Repository.clone_from_branch(
-        branch.replace("refs/heads/", ""), url, "main", obj.config, Path(".")
-    )
-    return repo
-
-
 def create_repo(config: dict) -> tuple[Repository, dict]:
     return Repository(config=RepoConfig.from_config(config)), config
 

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -1,11 +1,13 @@
-"""Commands related to the CSV (git) repository"""
+"""Commands related to the VCS (git) repository"""
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 
 import click
+from rich.console import Console
 from rich.markdown import Markdown
 
 from . import (
-    CliContext,
     CONFIG_PATH_HELP,
     create_console_logger,
 )
@@ -13,6 +15,14 @@ from ..constants import DEFAULT_CONFIG_FILE_NAME, DEFAULT_RUN_PROPERTIES_FILE_NA
 from ..steps.models import RunProperties
 from ..utilities.pyaml_env import parse_config
 from ..utilities.repo import Repository, RepoConfig
+
+
+@dataclass(frozen=True)
+class RepoContext:
+    config: Path
+    run_properties: Path
+    console: Console
+    verbose: bool
 
 
 @click.group("repo")
@@ -40,80 +50,76 @@ from ..utilities.repo import Repository, RepoConfig
 def repository(ctx, config, properties, verbose):
     """Manage CVS (git) repositories"""
     console = create_console_logger(show_path=False, verbose=verbose)
-    ctx.obj = CliContext(
-        config=(parse_config(config)),
-        repo=ctx.with_resource(
-            Repository(config=RepoConfig.from_config(parse_config(config)))
-        ),
-        console=console,
-        verbose=verbose,
-        run_properties=(parse_config(properties)),
+    ctx.obj = RepoContext(
+        config=config, run_properties=properties, console=console, verbose=verbose
     )
 
 
 @repository.command(help="The status of the current local repository")
 @click.pass_obj
-def status(obj: CliContext):
+def status(obj: RepoContext):
     """Print the status of the current repository"""
-    run_properties = RunProperties.from_configuration(obj.run_properties, obj.config)
+    config = parse_config(obj.config)
+    run_properties = RunProperties.from_configuration(
+        parse_config(obj.run_properties), config
+    )
     ci_branch = run_properties.versioning.branch
     console = obj.console
-    repo = obj.repo
+    with Repository(config=RepoConfig.from_config(config)) as repo:
+        console.print(
+            Markdown(f"Repository tracking [{repo.remote_url}]({repo.remote_url})")
+            if repo.remote_url
+            else Markdown("Repository not tracking any remote origin")
+        )
 
-    console.print(
-        Markdown(f"Repository tracking [{repo.remote_url}]({repo.remote_url})")
-        if repo.remote_url
-        else Markdown("Repository not tracking any remote origin")
-    )
+        console.print(
+            Markdown(
+                f"Branch as specified in _{DEFAULT_RUN_PROPERTIES_FILE_NAME}_: `{ci_branch}`"
+                if ci_branch
+                else f"No branch specified at `build.versioning.branch` in _{DEFAULT_RUN_PROPERTIES_FILE_NAME}_"
+            )
+        )
+        if not repo.has_valid_head:
+            console.log(
+                Markdown(
+                    f"Current branch `{repo.get_branch}` does **not** point to a valid reference."
+                )
+            )
+            return
 
-    console.print(
-        Markdown(
-            f"Branch as specified in _{DEFAULT_RUN_PROPERTIES_FILE_NAME}_: `{ci_branch}`"
-            if ci_branch
-            else f"No branch specified at `build.versioning.branch` in _{DEFAULT_RUN_PROPERTIES_FILE_NAME}_"
-        )
-    )
-    if not repo.has_valid_head:
         console.log(
             Markdown(
-                f"Current branch `{repo.get_branch}` does **not** point to a valid reference."
+                f"Current branch: `{repo.get_branch}` at `{repo.get_sha}`"
+                if repo.get_branch
+                else "Head of current branch is detached"
             )
         )
-        return
-
-    console.log(
-        Markdown(
-            f"Current branch: `{repo.get_branch}` at `{repo.get_sha}`"
-            if repo.get_branch
-            else "Head of current branch is detached"
-        )
-    )
-    base_revision = repo.base_revision
-    console.line(1)
-    console.log(Markdown(f"Configured base branch: `{repo.main_origin_branch}`"))
-    if repo.get_branch == repo.main_branch:
-        console.log(f"On main branch ({repo.main_branch})")
-        return
-    if base_revision:
-        console.log(
-            Markdown(
-                f"Base revision is `{base_revision.name_rev}` by _{base_revision.author}_ at "
-                f"{base_revision.committed_datetime}"
+        base_revision = repo.base_revision
+        console.line(1)
+        console.log(Markdown(f"Configured base branch: `{repo.main_origin_branch}`"))
+        if repo.get_branch == repo.main_branch:
+            console.log(f"On main branch ({repo.main_branch})")
+            return
+        if base_revision:
+            console.log(
+                Markdown(
+                    f"Base revision is `{base_revision.name_rev}` by _{base_revision.author}_ at "
+                    f"{base_revision.committed_datetime}"
+                )
             )
-        )
-        changes = obj.repo.changes_between(base_revision.hexsha, repo.get_sha)
-        console.log(
-            Markdown(
-                f"{len(changes)} commits between `{repo.main_origin_branch}` and `{repo.get_branch}`"
+            changes = repo.changes_between(base_revision.hexsha, repo.get_sha)
+            console.log(
+                Markdown(
+                    f"{len(changes)} commits between `{repo.main_origin_branch}` and `{repo.get_branch}`"
+                )
             )
-        )
-    else:
-        console.log(
-            Markdown(
-                f"Revision for `{repo.main_origin_branch}` not found. Cannot diff with base. "
-                f"Have you run `mpyl repo init`?"
+        else:
+            console.log(
+                Markdown(
+                    f"Revision for `{repo.main_origin_branch}` not found. Cannot diff with base. "
+                    f"Have you run `mpyl repo init`?"
+                )
             )
-        )
 
 
 @repository.command(help="Initialize the repository for a build run")
@@ -121,56 +127,66 @@ def status(obj: CliContext):
 @click.option("--pull", "-pr", type=click.INT, help="PR number to fetch")
 @click.option("--branch", "-b", type=click.STRING, help="Branch to fetch")
 @click.pass_obj
-def init(obj: CliContext, url, pull, branch):
-    repo = obj.repo
+def init(obj: RepoContext, url, pull, branch):
+    config = parse_config(obj.config)
+    run_properties = RunProperties.from_configuration(
+        parse_config(obj.run_properties), config
+    )
     console = obj.console
 
     console.log("Preparing repository for a new run...")
 
-    if not repo.remote_url:
-        with console.status("👷 Initializing remote origin") as progress:
-            repo_config = RepoConfig.from_config(obj.config).repo_credentials
-            url = url or (repo_config and repo_config.to_url)
-            remote = repo.init_remote(url)
-            progress.console.log(f"👷 Remote initialized at {remote.url}")
+    with Repository(config=RepoConfig.from_config(config)) as repo:
+        if not repo.remote_url:
+            with console.status("👷 Initializing remote origin") as progress:
+                repo_config = RepoConfig.from_config(config).repo_credentials
+                url = url or (repo_config and repo_config.to_url)
+                remote = repo.init_remote(url)
+                progress.console.log(f"👷 Remote initialized at {remote.url}")
 
-    console.log(f"✅ Repository tracking {repo.remote_url}")
+        console.log(f"✅ Repository tracking {repo.remote_url}")
 
-    properties = RunProperties.from_configuration(obj.run_properties, obj.config)
-    pr_number = pull or properties.versioning.pr_number
-    target_branch = (
-        f"PR-{pr_number}" if pr_number else branch or properties.versioning.branch
-    )
+        properties = run_properties
+        pr_number = pull or properties.versioning.pr_number
+        target_branch = (
+            f"PR-{pr_number}" if pr_number else branch or properties.versioning.branch
+        )
 
-    if pr_number:
-        console.log(Markdown(f"Initializing `{target_branch}`..."))
-        obj.repo.fetch_main_branch()
+        if pr_number:
+            console.log(Markdown(f"Initializing `{target_branch}`..."))
+            repo.fetch_main_branch()
 
-        if repo.get_branch != target_branch:
-            with console.status(f"👷 Fetching PR #{pr_number}"):
-                if repo.does_local_branch_exist(target_branch):
-                    console.log(
-                        Markdown(
-                            f"👷 Deleting local branch to prevent conflicts `{target_branch}`"
+            if repo.get_branch != target_branch:
+                with console.status(f"👷 Fetching PR #{pr_number}"):
+                    if repo.does_local_branch_exist(target_branch):
+                        console.log(
+                            Markdown(
+                                f"👷 Deleting local branch to prevent conflicts `{target_branch}`"
+                            )
                         )
+                        repo.delete_branch(target_branch)
+
+                    repo.fetch_pr(pr_number)
+                    repo.checkout_branch(target_branch)
+                    console.log(
+                        Markdown(f"✅ Fetched PR #{pr_number} to `{target_branch}`")
                     )
-                    repo.delete_branch(target_branch)
+            else:
+                console.log(Markdown(f"✅ HEAD is on `{target_branch}`"))
+            with console.status("Finding base"):
+                base_revision = repo.base_revision
+                if not base_revision:
+                    repo.fetch_main_branch()
 
-                repo.fetch_pr(pr_number)
-                repo.checkout_branch(target_branch)
-                console.log(Markdown(f"✅ Fetched PR #{pr_number} to `{target_branch}`"))
+                console.log(
+                    Markdown(
+                        f"✅ Found base `{repo.main_origin_branch}` at `{repo.base_revision}`"
+                    )
+                )
         else:
-            console.log(Markdown(f"✅ HEAD is on `{target_branch}`"))
-
-        console.log(
-            Markdown(
-                f"✅ Found base `{repo.main_origin_branch}` at `{repo.base_revision}`"
+            console.log(
+                Markdown(
+                    "❌ PR number not specified. Cannot initialize repository for build."
+                )
             )
-        )
-    else:
-        console.log(
-            Markdown(
-                "❌ PR number not specified. Cannot initialize repository for build."
-            )
-        )
-        sys.exit(1)
+            sys.exit(1)

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -1,5 +1,4 @@
 """Commands related to the VCS (git) repository"""
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -114,10 +113,11 @@ def status(obj: RepoContext):
                 )
             )
         else:
+            changes = repo.changes_in_branch()
             console.log(
                 Markdown(
                     f"Revision for `{repo.main_origin_branch}` not found. Cannot diff with base. "
-                    f"Have you run `mpyl repo init`?"
+                    f"*{len(changes)}* (grafted) commits on `{repo.get_branch}`"
                 )
             )
 
@@ -163,11 +163,13 @@ def init(obj: RepoContext, url: str, pull: int, branch: str, pristine: bool):
             parse_config(obj.run_properties), config
         )
         pr_number = pull or properties.versioning.pr_number
-        target_branch = (
-            f"PR-{pr_number}" if pr_number else branch or properties.versioning.branch
-        )
 
         if pr_number:
+            target_branch = (
+                f"PR-{pr_number}"
+                if pr_number
+                else branch or properties.versioning.branch
+            )
             console.log(Markdown(f"Initializing `{target_branch}`..."))
             repo.fetch_main_branch()
 
@@ -198,10 +200,3 @@ def init(obj: RepoContext, url: str, pull: int, branch: str, pristine: bool):
                         f"✅ Found base `{repo.main_origin_branch}` at `{repo.base_revision}`"
                     )
                 )
-        else:
-            console.log(
-                Markdown(
-                    "❌ PR number not specified. Cannot initialize repository for build."
-                )
-            )
-            sys.exit(1)

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -29,8 +29,8 @@ class RepoContext:
 @click.option(
     "--config",
     "-c",
-    required=True,
-    type=click.Path(exists=True),
+    required=False,
+    type=click.Path(exists=False),
     help=CONFIG_PATH_HELP,
     envvar="MPYL_CONFIG_PATH",
     default=DEFAULT_CONFIG_FILE_NAME,
@@ -122,18 +122,41 @@ def status(obj: RepoContext):
             )
 
 
+def _get_pristine_repo(obj: RepoContext, url: str, branch: str):
+    repo = Repository.clone_from_branch(
+        branch.replace("refs/heads/", ""), url, "main", obj.config, Path(".")
+    )
+    return repo
+
+
+def create_repo(config: dict) -> tuple[Repository, dict]:
+    return Repository(config=RepoConfig.from_config(config)), config
+
+
 @repository.command(help="Initialize the repository for a build run")
 @click.option("--url", "-u", type=click.STRING, help="URL to the remote repository")
 @click.option("--pull", "-pr", type=click.INT, help="PR number to fetch")
 @click.option("--branch", "-b", type=click.STRING, help="Branch to fetch")
+@click.option(
+    "--pristine",
+    "-p",
+    is_flag=True,
+    default=False,
+    help="When set, the local folder is assumed to be empty and a `git clone` "
+    "will be performed instead of pulling the latest changes from the remote.",
+)
 @click.pass_obj
-def init(obj: RepoContext, url, pull, branch):
-    config = parse_config(obj.config)
+def init(obj: RepoContext, url: str, pull: int, branch: str, pristine: bool):
     console = obj.console
 
     console.log("Preparing repository for a new run...")
 
-    with Repository(config=RepoConfig.from_config(config)) as repo:
+    with Repository(
+        config=RepoConfig.from_config(parse_config(obj.config))
+    ) if pristine else Repository.clone_from_branch(
+        branch.replace("refs/heads/", ""), url, "main", obj.config, Path(".")
+    ) as repo:
+        config = parse_config(obj.config)
         if not repo.remote_url:
             with console.status("👷 Initializing remote origin") as progress:
                 repo_config = RepoConfig.from_config(config).repo_credentials

--- a/src/mpyl/cli/repository.py
+++ b/src/mpyl/cli/repository.py
@@ -129,9 +129,6 @@ def status(obj: RepoContext):
 @click.pass_obj
 def init(obj: RepoContext, url, pull, branch):
     config = parse_config(obj.config)
-    run_properties = RunProperties.from_configuration(
-        parse_config(obj.run_properties), config
-    )
     console = obj.console
 
     console.log("Preparing repository for a new run...")
@@ -146,7 +143,9 @@ def init(obj: RepoContext, url, pull, branch):
 
         console.log(f"✅ Repository tracking {repo.remote_url}")
 
-        properties = run_properties
+        properties = RunProperties.from_configuration(
+            parse_config(obj.run_properties), config
+        )
         pr_number = pull or properties.versioning.pr_number
         target_branch = (
             f"PR-{pr_number}" if pr_number else branch or properties.versioning.branch

--- a/src/mpyl/reporting/targets/github.py
+++ b/src/mpyl/reporting/targets/github.py
@@ -27,7 +27,7 @@ Checks can be referred to from branch protection rules, in order to prevent faul
  Github app to your repository.
  2. Go to your repository's *Setting* -> *Integrations* -> *Github Apps* and click **Configure** for*_MPyL Pipeline*
  3. In the app's settings page, scroll down and click **Generate a private key**
- 4. The private key needs to be made available at the location configured in `csv.targets.app.privateKeyPath` at
+ 4. The private key needs to be made available at the location configured in `vcs.targets.app.privateKeyPath` at
   runtime.
 
 """

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -18,6 +18,8 @@ from ...utilities.subprocess import custom_check_output
 
 
 class TestSbt(Step):
+    __test__ = False
+
     def __init__(self, logger: Logger) -> None:
         super().__init__(
             logger=logger,

--- a/src/mpyl/utilities/junit/__init__.py
+++ b/src/mpyl/utilities/junit/__init__.py
@@ -23,6 +23,7 @@ class JunitTestSpec(ArtifactSpec):
 
 @dataclass(frozen=True)
 class TestRunSummary:
+    __test__ = False
     tests: int
     failures: int
     errors: int

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -105,8 +105,11 @@ class Repository:  # pylint: disable=too-many-public-methods
     @property
     def base_revision(self) -> Optional[Commit]:
         main = self.main_origin_branch
-        local_main = main.replace("origin/", "")
-        return self._safe_ref_parse(local_main) or self._safe_ref_parse(main)
+        return self._safe_ref_parse(main)
+
+    @property
+    def root_commit_hex(self) -> str:
+        return self._repo.git.rev_list("--max-parents=0", "HEAD").splitlines()[-1]
 
     @property
     def get_tag(self) -> Optional[str]:
@@ -157,9 +160,7 @@ class Repository:  # pylint: disable=too-many-public-methods
 
     def changes_in_branch(self) -> list[Revision]:
         base_ref = self.base_revision
-        base_hex = (
-            base_ref if base_ref else self._repo.git.rev_list("--max-parents=0", "HEAD")
-        )
+        base_hex = base_ref.hexsha if base_ref else self.root_commit_hex
 
         head_hex = self._repo.active_branch.commit.hexsha
         logging.debug(

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -103,13 +103,13 @@ class Repository:  # pylint: disable=too-many-public-methods
             return None
 
     @property
+    def root_commit_hex(self) -> str:
+        return self._repo.git.rev_list("--max-parents=0", "HEAD").splitlines()[-1]
+
+    @property
     def base_revision(self) -> Optional[Commit]:
         main = self.main_origin_branch
         return self._safe_ref_parse(main)
-
-    @property
-    def root_commit_hex(self) -> str:
-        return self._repo.git.rev_list("--max-parents=0", "HEAD").splitlines()[-1]
 
     @property
     def get_tag(self) -> Optional[str]:

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -214,9 +214,7 @@ class Repository:  # pylint: disable=too-many-public-methods
         curr_rev_tag = self.get_tag
 
         if curr_rev_tag != current_tag:
-            logging.error(
-                f"HEAD is not at {curr_rev_tag} not at expected {current_tag}"
-            )
+            logging.error(f"HEAD is at {curr_rev_tag} not at expected `{current_tag}`")
             return []
 
         return self.changes_in_merge_commit()

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -136,6 +136,9 @@ class Repository:  # pylint: disable=too-many-public-methods
     def main_origin_branch(self) -> str:
         return f"origin/{self.main_branch}"
 
+    def fit_for_tag_build(self, tag: str) -> bool:
+        return len(self.changes_in_tagged_commit(tag)) > 0
+
     def __get_filter_patterns(self):
         return ["--"] + [f":!{pattern}" for pattern in self._config.ignore_patterns]
 

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -14,6 +14,7 @@ from git.objects import Commit
 from gitdb.exc import BadName
 
 from ...project import Project
+from ...utilities.pyaml_env import parse_config
 
 
 @dataclass(frozen=True)
@@ -242,6 +243,21 @@ class Repository:  # pylint: disable=too-many-public-methods
 
     def fetch_pr(self, pr_number: int):
         return self._repo.remote().fetch(f"pull/{pr_number}/head:PR-{pr_number}")
+
+    @staticmethod
+    def clone_from_branch(
+        branch_name: str, url: str, base_branch: str, config_path: Path, path: Path
+    ):
+        Repo.clone_from(
+            url,
+            path,
+            allow_unsafe_protocols=True,
+            shallow_exclude=base_branch,
+            single_branch=True,
+            branch=branch_name,
+        )
+        parsed_config = parse_config(config_path)
+        return Repository(RepoConfig.from_config(parsed_config))
 
     def checkout_branch(self, branch_name: str):
         self._repo.git.switch(branch_name)

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -114,7 +114,7 @@ class Repository:  # pylint: disable=too-many-public-methods
     @property
     def get_tag(self) -> Optional[str]:
         current_revision = self._repo.head.commit
-        current_tag = self._repo.git.describe(current_revision, tags=True)
+        current_tag = self._repo.git.tag(current_revision, points_at=True)
         logging.debug(f"Current revision: {current_revision} tag: {current_tag}")
         return current_tag
 

--- a/tests/cli/test_resources/repo_help_text.txt
+++ b/tests/cli/test_resources/repo_help_text.txt
@@ -4,7 +4,7 @@ Usage: mpyl repo [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -c, --config PATH      Path to the config.yml. Can be set via
-                         `MPYL_CONFIG_PATH` env var.   [required]
+                         `MPYL_CONFIG_PATH` env var.
   -p, --properties PATH  Path to run properties  [default: run_properties.yml]
   -v, --verbose
   --help                 Show this message and exit.

--- a/tests/cli/test_resources/repo_help_text.txt
+++ b/tests/cli/test_resources/repo_help_text.txt
@@ -10,6 +10,5 @@ Options:
   --help                 Show this message and exit.
 
 Commands:
-  credentials  Return repository credentials
-  init         Initialize the repository for a build run
-  status       The status of the current local repository
+  init    Initialize the repository for a build run
+  status  The status of the current local repository


### PR DESCRIPTION
Clones out repo in minimalist way, only including differences from main.

<img width="661" alt="Screenshot 2023-09-09 at 17 26 47" src="https://github.com/Vandebron/mpyl/assets/1911436/90a155ac-65bf-4fb8-aa58-2d0808a22f7c">

branch: feature/TECH-561-test-mpyl-in-gha

----
### 📕 [TECH-561](https://vandebron.atlassian.net/browse/TECH-561) Create regression test for tag builds <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:73eb6738-a8dc-4e71-beb2-16761407e54e/44a3caa2-b498-4ee1-927d-bdb0901a683e/24" width="24" height="24" alt="sam@vandebron.nl" /> 
Create a github action for a PR that runs in the mpyl repo on master with the test version of the PR.

This is to ensure that the tag flow doesn't break with every merge.

Ensure that the jenkinsfile in the mpyl repo is the same as the monorepo one (i.e. same mpyl commands are run in the same order).

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-233/4/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-233.test.nl/)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-233.test.nl/)*, *[sbtservice](https://sbtservice-233.test.nl/)*, *sparkJob*  


[TECH-561]: https://vandebron.atlassian.net/browse/TECH-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ