### PR TITLE
[TECH-513] Ask for target input when deploying a tag

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -268,9 +268,8 @@ def select_target():
         "Which environment do you want to deploy to?",
         show_selected=True,
         choices=[
-            Choice(title="Acceptance", value=Target.ACCEPTANCE.name),
-            Choice(title="PullRequestBase", value=Target.PULL_REQUEST_BASE.name),
-            Choice(title="Production", value=Target.PRODUCTION.name),
+            Choice(title=t.name, value=t.name)
+            for t in [Target.ACCEPTANCE, Target.PULL_REQUEST_BASE, Target.PRODUCTION]
         ],
     ).ask()
 

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -283,7 +283,7 @@ def ask_for_tag_input(ctx, _param, value) -> Optional[str]:
     return value
 
 
-def ask_for_target_input(ctx, _param, value) -> Optional[str]:
+def ask_for_target_input(_, _param, value) -> Optional[str]:
     if value == "not_set":
         return None
     if value == "prompt":

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -268,9 +268,9 @@ def select_target():
         "Which environment do you want to deploy to?",
         show_selected=True,
         choices=[
-            Choice(title="Acceptance", value=Target.ACCEPTANCE.value),
-            Choice(title="PullRequestBase", value=Target.PULL_REQUEST_BASE.value),
-            Choice(title="Production", value=Target.PRODUCTION.value),
+            Choice(title="Acceptance", value=Target.ACCEPTANCE.name),
+            Choice(title="PullRequestBase", value=Target.PULL_REQUEST_BASE.name),
+            Choice(title="Production", value=Target.PRODUCTION.name),
         ],
     ).ask()
 
@@ -280,14 +280,6 @@ def ask_for_tag_input(ctx, _param, value) -> Optional[str]:
         return None
     if value == "prompt":
         return select_tag(ctx)
-    return value
-
-
-def ask_for_target_input(_, _param, value) -> Optional[str]:
-    if value == "not_set":
-        return None
-    if value == "prompt":
-        return select_target()
     return value
 
 
@@ -364,13 +356,6 @@ def ask_for_target_input(_, _param, value) -> Optional[str]:
     default="not_set",
     callback=ask_for_tag_input,
 )
-@click.option(
-    "--target",
-    is_flag=False,
-    flag_value="prompt",
-    default="not_set",
-    callback=ask_for_target_input,
-)
 @click.pass_context
 def jenkins(  # pylint: disable=too-many-arguments
     ctx,
@@ -383,7 +368,6 @@ def jenkins(  # pylint: disable=too-many-arguments
     background,
     silent,
     tag,
-    target,
 ):
     upgrade_check = None
     try:
@@ -412,7 +396,7 @@ def jenkins(  # pylint: disable=too-many-arguments
             verbose=not silent or ctx.obj.verbose,
             follow=not background,
             tag=tag,
-            tag_target=target,
+            tag_target=getattr(Target, select_target()) if tag else None,
         )
 
         run_jenkins(run_argument)

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -383,6 +383,7 @@ def jenkins(  # pylint: disable=too-many-arguments
     background,
     silent,
     tag,
+    target,
 ):
     upgrade_check = None
     try:
@@ -411,6 +412,7 @@ def jenkins(  # pylint: disable=too-many-arguments
             verbose=not silent or ctx.obj.verbose,
             follow=not background,
             tag=tag,
+            tag_target=target,
         )
 
         run_jenkins(run_argument)

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -27,6 +27,7 @@ class JenkinsRunParameters:
     pipeline_parameters: dict
     verbose: bool
     follow: bool
+    tag_target: Target = Target.ACCEPTANCE
     tag: Optional[str] = None
 
 
@@ -89,7 +90,7 @@ def run_jenkins(run_config: JenkinsRunParameters):
             try:
                 pipeline_info = (
                     Pipeline(
-                        target=Target.ACCEPTANCE,
+                        target=run_config.tag_target,
                         tag=run_config.tag,
                         url="https://tag-url",
                         pipeline=run_config.pipeline,
@@ -103,6 +104,11 @@ def run_jenkins(run_config: JenkinsRunParameters):
                 )
                 if not pipeline_info:
                     return
+
+                if run_config.tag:
+                    run_config.pipeline_parameters["BUILD_PARAMS"] += {
+                        "DEPLOY_CHOICE": run_config.tag_target
+                    }
 
                 status.start()
                 status.update(

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -28,7 +28,7 @@ class JenkinsRunParameters:
     verbose: bool
     follow: bool
     tag: Optional[str] = None
-    tag_target: Optional[Target] = None
+    tag_target: Target = Target.ACCEPTANCE
 
 
 def get_token(github_config: GithubConfig):

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -108,7 +108,7 @@ def run_jenkins(run_config: JenkinsRunParameters):
                 if run_config.tag:
                     run_config.pipeline_parameters[
                         "DEPLOY_CHOICE"
-                    ] = run_config.tag_target.name
+                    ] = run_config.tag_target.value
 
                 status.start()
                 status.update(

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -27,8 +27,8 @@ class JenkinsRunParameters:
     pipeline_parameters: dict
     verbose: bool
     follow: bool
-    tag_target: Target = Target.ACCEPTANCE
     tag: Optional[str] = None
+    tag_target: Optional[Target] = None
 
 
 def get_token(github_config: GithubConfig):
@@ -108,7 +108,7 @@ def run_jenkins(run_config: JenkinsRunParameters):
                 if run_config.tag:
                     run_config.pipeline_parameters[
                         "DEPLOY_CHOICE"
-                    ] = run_config.tag_target
+                    ] = run_config.tag_target.name
 
                 status.start()
                 status.update(

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -106,9 +106,9 @@ def run_jenkins(run_config: JenkinsRunParameters):
                     return
 
                 if run_config.tag:
-                    run_config.pipeline_parameters["BUILD_PARAMS"] += {
-                        "DEPLOY_CHOICE": run_config.tag_target
-                    }
+                    run_config.pipeline_parameters[
+                        "DEPLOY_CHOICE"
+                    ] = run_config.tag_target
 
                 status.start()
                 status.update(


### PR DESCRIPTION
mpyl CLI jenkins improvements
- [x] be able to set mpyl version from the cli (not just test version)
- [x] be able to set the target when deploying tags

----
### 📕 [TECH-569](https://vandebron.atlassian.net/browse/TECH-569) Add target argument to cli tag builds <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-235/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-235.test.nl/)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-235.test.nl/)*, *[sbtservice](https://sbtservice-235.test.nl/)*, *sparkJob*  


[TECH-569]: https://vandebron.atlassian.net/browse/TECH-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ