### PR TITLE
[TECH-491] Filter out files without any net changes from invalidation logic

### DIFF
--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -29,6 +29,8 @@ class Revision:
 
     @staticmethod
     def from_output(text: str):
+        """From the following command: `git log --pretty=format:"hash %H" --name-only
+        --no-abbrev-commit <from>..<until>`"""
         sections = []
         current_section: list[str] = []
         lines = text.splitlines()

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -25,6 +25,29 @@ class Revision:
     """Git hash for this revision"""
     files_touched: set[str]
     """Paths to files that were altered in this hash"""
+    BREAK_WORD = "hash "
+
+    @staticmethod
+    def from_output(text: str):
+        sections = []
+        current_section: list[str] = []
+        lines = text.splitlines()
+        for line in lines:
+            if line.startswith(Revision.BREAK_WORD):
+                if current_section:
+                    sections.append(current_section)
+                current_section = [line.replace(Revision.BREAK_WORD, "")]
+            else:
+                current_section.append(line)
+
+        if current_section:
+            sections.append(current_section)
+
+        revisions = [
+            Revision(index, section[0], set([line for line in section if line][1:]))
+            for index, section in enumerate(reversed(sections))
+        ]
+        return revisions
 
 
 @dataclass(frozen=True)
@@ -142,20 +165,6 @@ class Repository:  # pylint: disable=too-many-public-methods
     def __get_filter_patterns(self):
         return ["--"] + [f":!{pattern}" for pattern in self._config.ignore_patterns]
 
-    def __to_revision(
-        self, count: int, revision: Commit, files_touched_in_branch: set[str]
-    ) -> Revision:
-        files_in_revision = set(
-            self._repo.git.diff_tree(
-                self.__get_filter_patterns(),
-                no_commit_id=True,
-                name_only=True,
-                r=str(revision),
-            ).splitlines()
-        )
-        intersection = files_in_revision.intersection(files_touched_in_branch)
-        return Revision(count, str(revision), intersection)
-
     def changes_between(self, base_revision: str, head_revision: str) -> list[Commit]:
         return list(
             reversed(list(self._repo.iter_commits(f"{base_revision}..{head_revision}")))
@@ -166,34 +175,14 @@ class Repository:  # pylint: disable=too-many-public-methods
         base_hex = base_ref.hexsha if base_ref else self.root_commit_hex
 
         head_hex = self._repo.active_branch.commit.hexsha
-        logging.debug(
-            f"Base reference: [bright_blue]{base_ref or '(grafted)'}[/bright_blue] [italic]{base_hex}[/italic]"
-        )
 
-        revisions = self.changes_between(base_hex, head_hex)
-
-        logging.debug(
-            f"Found {len(revisions)} revisions in branch: {[r.hexsha for r in revisions]}"
-        )
-
-        if not revisions:
-            return []
-
-        changed_files = list(
-            itertools.chain.from_iterable(
-                [
-                    self._repo.git.diff_tree(
-                        rev, name_only=True, no_commit_id=True, r=True
-                    ).splitlines()
-                    for rev in revisions
-                ]
-            )
-        )
-
-        return [
-            self.__to_revision(count, rev, set(changed_files))
-            for count, rev in enumerate(revisions)
-        ]
+        revs = self._repo.git.log(
+            f'--pretty=format:"{Revision.BREAK_WORD}%H"',
+            "--name-only",
+            "--no-abbrev-commit",
+            f"{base_hex}..{head_hex}",
+        ).replace('"', "")
+        return Revision.from_output(revs)
 
     def changes_in_commit(self) -> set[str]:
         changed: set[str] = set(

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -28,12 +28,18 @@ class Revision:
     BREAK_WORD = "hash "
 
     @staticmethod
-    def from_output(text: str):
-        """From the following command: `git log --pretty=format:"hash %H" --name-only
-        --no-abbrev-commit <from>..<until>`"""
+    def from_git_output(git_log_output: str, git_dif_output: str = ""):
+        """
+        :param git_dif_output: output of `git log --pretty=format:"hash %H" --name-only
+        --no-abbrev-commit <from>..<until>`
+        :param git_log_output: output of `git diff --name-only <from>..<until>`
+        """
+
+        change_set = set(git_dif_output.splitlines())
+
         sections = []
         current_section: list[str] = []
-        lines = text.splitlines()
+        lines = git_log_output.splitlines()
         for line in lines:
             if line.startswith(Revision.BREAK_WORD):
                 if current_section:
@@ -46,7 +52,11 @@ class Revision:
             sections.append(current_section)
 
         revisions = [
-            Revision(index, section[0], set([line for line in section if line][1:]))
+            Revision(
+                index,
+                section[0],
+                {line for line in section[1:] if line in change_set},
+            )
             for index, section in enumerate(reversed(sections))
         ]
         return revisions
@@ -177,7 +187,10 @@ class Repository:  # pylint: disable=too-many-public-methods
         ]
 
         revs = self._repo.git.log(*command).replace('"', "")
-        return Revision.from_output(revs)
+        changed_files = self._repo.git.diff(
+            f"{base_revision}..{head_revision}", name_only=True
+        )
+        return Revision.from_git_output(revs, changed_files)
 
     def changes_in_branch(self) -> list[Revision]:
         base_ref = self.base_revision

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -28,14 +28,14 @@ class Revision:
     BREAK_WORD = "hash "
 
     @staticmethod
-    def from_git_output(git_log_output: str, git_dif_output: str = ""):
+    def from_git_output(git_log_output: str, git_diff_output: str):
         """
-        :param git_dif_output: output of `git log --pretty=format:"hash %H" --name-only
+        :param git_diff_output: output of `git log --pretty=format:"hash %H" --name-only
         --no-abbrev-commit <from>..<until>`
         :param git_log_output: output of `git diff --name-only <from>..<until>`
         """
 
-        change_set = set(git_dif_output.splitlines())
+        change_set = set(git_diff_output.splitlines())
 
         sections = []
         current_section: list[str] = []

--- a/tests/projects/repo/test_repo.py
+++ b/tests/projects/repo/test_repo.py
@@ -2,14 +2,14 @@ import os
 
 import pytest
 
-from src.mpyl.utilities.repo import RepoConfig
+from src.mpyl.utilities.repo import RepoConfig, Revision
 from tests import root_test_path
 from tests.test_resources import test_data
 from tests.test_resources.test_data import get_config_values
 
 
 class TestRepo:
-    resource_path = root_test_path / "test_resources"
+    resource_path = root_test_path / "test_resources" / "repository"
 
     @pytest.mark.skipif(
         condition="GITHUB_JOB" in os.environ,
@@ -28,3 +28,15 @@ class TestRepo:
         repo_credentials = config.repo_credentials
         assert repo_credentials.url == "https://github.com/acme/repo.git"
         assert repo_credentials.to_url == "https://github.com/acme/repo.git"
+
+    def test_map_git_log_to_revisions(self):
+        text = (self.resource_path / "git_log.txt").read_text(encoding="utf-8")
+        revisions = Revision.from_output(text)
+
+        first_revision = revisions[0]
+        assert first_revision.ord == 0
+        assert first_revision.hash == "e9ff18931070de4803da2190274d5fccb0362824"
+        assert first_revision.files_touched == {"projects/service/src/sum.js"}
+
+        last_revision = revisions[-1]
+        assert last_revision.ord == 8

--- a/tests/projects/repo/test_repo.py
+++ b/tests/projects/repo/test_repo.py
@@ -29,6 +29,7 @@ class TestRepo:
         assert repo_credentials.url == "https://github.com/acme/repo.git"
         assert repo_credentials.to_url == "https://github.com/acme/repo.git"
 
+    # git log --pretty=format:"hash %H" --name-only --no-abbrev-commit from..until
     def test_map_git_log_to_revisions(self):
         text = (self.resource_path / "git_log.txt").read_text(encoding="utf-8")
         revisions = Revision.from_output(text)

--- a/tests/projects/repo/test_repo.py
+++ b/tests/projects/repo/test_repo.py
@@ -30,8 +30,10 @@ class TestRepo:
         assert repo_credentials.to_url == "https://github.com/acme/repo.git"
 
     def test_map_git_log_to_revisions(self):
-        text = (self.resource_path / "git_log.txt").read_text(encoding="utf-8")
-        revisions = Revision.from_output(text)
+        log_text = (self.resource_path / "git_log.txt").read_text(encoding="utf-8")
+        diff_text = (self.resource_path / "git_diff.txt").read_text(encoding="utf-8")
+        revisions = Revision.from_git_output(log_text, diff_text)
+        print(revisions)
 
         first_revision = revisions[0]
         assert first_revision.ord == 0
@@ -40,3 +42,6 @@ class TestRepo:
 
         last_revision = revisions[-1]
         assert last_revision.ord == 8
+        assert (
+            last_revision.files_touched == set()
+        ), "Pipfile does not have a net change"

--- a/tests/projects/repo/test_repo.py
+++ b/tests/projects/repo/test_repo.py
@@ -29,7 +29,6 @@ class TestRepo:
         assert repo_credentials.url == "https://github.com/acme/repo.git"
         assert repo_credentials.to_url == "https://github.com/acme/repo.git"
 
-    # git log --pretty=format:"hash %H" --name-only --no-abbrev-commit from..until
     def test_map_git_log_to_revisions(self):
         text = (self.resource_path / "git_log.txt").read_text(encoding="utf-8")
         revisions = Revision.from_output(text)

--- a/tests/test_resources/repository/git_diff.txt
+++ b/tests/test_resources/repository/git_diff.txt
@@ -1,0 +1,3 @@
+.github/workflows/build-mpyl-pipeline.yml
+projects/sbt-service/src/main/scala/vandebron/mpyl/Main.scala
+projects/service/src/sum.js

--- a/tests/test_resources/repository/git_log.txt
+++ b/tests/test_resources/repository/git_log.txt
@@ -1,0 +1,25 @@
+hash beb2d65d2c6d359d302e765c01a1249cfc16977a
+Pipfile
+
+hash bd8894a33d79feea4c748ab62d5447c7688086ad
+.github/workflows/build-mpyl-pipeline.yml
+
+hash 0956b92717bd184d763ce8968441fd1cbd8b4f27
+.github/workflows/build-mpyl-pipeline.yml
+
+hash 86155bf8a930d50a12e7ba4d8786d11c744d4529
+Pipfile
+
+hash 9a49a1a4ee006df7f732dcfc2cc3fde9ed10ce54
+.github/workflows/build-mpyl-pipeline.yml
+Pipfile
+
+hash 993fdc9128f581719bd6cb98c04f0ec642449690
+Pipfile
+
+hash 9215d9c863c1fbf842de46bda189c92fa2226716
+hash 8dba98c95330b89dd7e665c3a16982a84f30d0ba
+projects/sbt-service/src/main/scala/vandebron/mpyl/Main.scala
+
+hash e9ff18931070de4803da2190274d5fccb0362824
+projects/service/src/sum.js


### PR DESCRIPTION
So that, when a change to a file is reverted it is not considered dirty.

branch: feature/TECH-491-speed-up-revision-detection

----
### 📕 [TECH-491](https://vandebron.atlassian.net/browse/TECH-491) MPyL Improvements <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Improve and extend our CI-CD capabilities

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-237/3/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-237.test.nl/)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-237.test.nl/)*, *[sbtservice](https://sbtservice-237.test.nl/)*, *sparkJob*  


[TECH-491]: https://vandebron.atlassian.net/browse/TECH-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ