### PR TITLE
Readd Dagster definition section in mpyl-config-yaml-schema

### DIFF
--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -384,3 +384,23 @@ definitions:
     dependencies:
       accessKeyId: [ secretAccessKey ]
       secretAccessKey: [ accessKeyId ]
+  Dagster:
+    title: Dagster
+    type: object
+    additionalProperties: false
+    properties:
+      baseNamespace:
+        description: "Namespace that contains dagster instances"
+        type: string
+      workspaceConfigMap:
+        description: "Configmap that contains the dagster workspace configuration"
+        type: string
+      workspaceFileKey:
+        description: "Key of the workspaceConfigMap entry that contains the list of servers that are hosted on the dagster instance"
+        type: string
+      daemon:
+        description: "Name of the kubernetes instance that runs the dagster daemon"
+        type: string
+      webserver:
+        description: "Name of the kubernetes instance that runs the dagster web UI, default"
+        type: string


### PR DESCRIPTION
@SamTheisens  somehow the release notes commit 1de6bc5a0fae3e8f65586712e2bc7905a8d26f35 got rid of the Dagster definition section in the schema.
If that was not an accident, let's discuss :-) if it was an accident, this is the PR to revert it 😄 

----
 # ⚠️ Could not find ticket corresponding to `fix/readd-dagster-definition-in-yaml. Does your branch name follow the correct pattern?