### PR TITLE
[TECH-488] Remove filtering from project commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                             sh "pipenv install -d --skip-lock"
                             sh "pipenv run mpyl version"
                             sh "pipenv run mpyl health --ci --upgrade"
-                            sh "pipenv run mpyl projects lint --all"
+                            sh "pipenv run mpyl projects lint"
                             sh "pipenv run mpyl projects upgrade"
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -13,16 +13,6 @@ from ....steps.deploy.k8s.chart import ChartBuilder
 from ....utilities.repo import Repository
 
 
-def __is_override_base(project_path: str) -> bool:
-    folder = Path(project_path).parent
-    return len(list(folder.glob("project-override*.yml"))) > 0
-
-
-def _find_project_paths(repo: Repository, path_filter: str) -> list[str]:
-    project_paths = repo.find_projects(path_filter)
-    return [path for path in project_paths if not __is_override_base(path)]
-
-
 def __load_project(
     console: Optional[Console],
     root_dir: Path,

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -127,12 +127,6 @@ def show_project(ctx, name):
 
 @projects.command(help="Validate the yaml of changed projects against their schema")
 @click.option(
-    "--all",
-    "all_",
-    is_flag=True,
-    help="Validate all project yaml's, regardless of changes on branch",
-)
-@click.option(
     "--extended",
     "-e",
     "extended",
@@ -140,17 +134,17 @@ def show_project(ctx, name):
     help="Enable extra validations like PR namespace linkup",
 )
 @click.pass_obj
-def lint(obj: ProjectsContext, all_, extended):
+def lint(obj: ProjectsContext, extended):
     loaded_projects = _check_and_load_projects(
         console=obj.cli.console,
         repo=obj.cli.repo,
-        project_paths=_find_project_paths(all_, obj.cli.repo, obj.filter),
+        project_paths=_find_project_paths(obj.cli.repo, obj.filter),
         strict=True,
     )
     all_projects = _check_and_load_projects(
         console=None,
         repo=obj.cli.repo,
-        project_paths=_find_project_paths(True, obj.cli.repo, ""),
+        project_paths=_find_project_paths(obj.cli.repo, ""),
         strict=False,
     )
     _assert_unique_project_names(
@@ -161,7 +155,7 @@ def lint(obj: ProjectsContext, all_, extended):
         _assert_correct_project_linkup(
             console=obj.cli.console,
             target=Target.PULL_REQUEST,
-            projects=all_projects if all_ else loaded_projects,
+            projects=loaded_projects,
             all_projects=all_projects,
             pr_identifier=123,
         )
@@ -176,9 +170,8 @@ def lint(obj: ProjectsContext, all_, extended):
 )
 @click.pass_obj
 def upgrade(obj: ProjectsContext, apply: bool):
-    paths = map(Path, _find_project_paths(True, obj.cli.repo, ""))
+    paths = map(Path, _find_project_paths(obj.cli.repo, ""))
     candidates = check_upgrades_needed(list(paths), PROJECT_UPGRADERS)
-    console = obj.cli.console
     if not apply:
         upgradable = check_upgrade(console, candidates)
         number_in_need_of_upgrade = len(upgradable)

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -544,14 +544,18 @@ def validate_project(file: TextIO) -> dict:
     return yaml_values
 
 
-def load_project(root_dir: Path, project_path: Path, strict: bool = True) -> Project:
+def load_project(
+    root_dir: Path, project_path: Path, strict: bool = True, log: bool = True
+) -> Project:
     """
     Load a `project.yml` to `Project` data class
     :param root_dir: root source directory
     :param project_path: relative path from `root_dir` to the `project.yml`
     :param strict: indicates whether the schema should be validated
+    :param log: indicates whether problems should be logged as warning
     :return: `Project` data class
     """
+    log_level = logging.WARNING if log else logging.DEBUG
     with open(root_dir / project_path, encoding="utf-8") as file:
         try:
             start = time.time()
@@ -564,16 +568,16 @@ def load_project(root_dir: Path, project_path: Path, strict: bool = True) -> Pro
             )
             return project
         except jsonschema.exceptions.ValidationError as exc:
-            logging.warning(
-                f"{project_path} does not comply with schema: {exc.message}"
+            logging.log(
+                log_level, f"{project_path} does not comply with schema: {exc.message}"
             )
             raise
         except TypeError:
             traceback.print_exc()
-            logging.warning("Type error", exc_info=True)
+            logging.log(log_level, "Type error", exc_info=True)
             raise
         except Exception:
-            logging.warning(f"Failed to load {project_path}", exc_info=True)
+            logging.log(log_level, f"Failed to load {project_path}", exc_info=True)
             raise
 
 

--- a/tests/cli/commands/test_cli.py
+++ b/tests/cli/commands/test_cli.py
@@ -42,7 +42,7 @@ class TestCli:
     def test_projects_lint_all_output(self):
         result = self.runner.invoke(
             main_group,
-            ["projects", "-c", str(self.config_path), "lint", "--all"],
+            ["projects", "-c", str(self.config_path), "lint"],
         )
         assert re.match(
             r"(.|\n)*Validated .* projects\. .* valid, .* invalid\n\n.*No duplicate project names found",


### PR DESCRIPTION
The logic was quite complicated and implicit. Its only goal was to filter out overridden projects. It's probably simpler and cleaner to just make sure that the base projects comply with the schema, while we're waiting for a different solution to deployment variations.   

branch: feature/TECH-488-filter-out-project-overrides

----
### 📕 [TECH-488](https://vandebron.atlassian.net/browse/TECH-488) Validate namespace replacement logic <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Check namespace replacement

URLs should be interpolated with the name of the project

Add a command to `mpyl build health` to validate unique project names

* after loading all the projects, validating the yamls then check project names
* fail pipeline if project name is not unique
* check all project names in lower case -> give suggestions if there's a case-sensitity issue

create post about this logic + add it to mpyl documentation

🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-256/5/display/redirect) ✅ Successful, started by _Sam Theisens_  
🚀 *[cloudfront-service](https://cloudfront-service-256.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-256.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-256.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-488]: https://vandebron.atlassian.net/browse/TECH-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ