### PR TITLE
fix/TECH 630 Implement missing project yaml fields

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -419,7 +419,8 @@ disable=raw-checker-failed,
         too-few-public-methods,
         logging-fstring-interpolation,
         missing-class-docstring,
-        missing-function-docstring
+        missing-function-docstring,
+        too-many-instance-attributes
 # TODO: re-enable documentation related lint checks
 
 

--- a/run_properties.yml
+++ b/run_properties.yml
@@ -1,3 +1,4 @@
+mpylVersion: 1.0.9
 build:
   run:
     id: !ENV ${BUILD_ID:1}
@@ -21,8 +22,7 @@ stages:
     icon: '🏗️'
   - name: 'test'
     icon: '📋'
-  - name : 'deploy'
+  - name: 'deploy'
     icon: '🚀'
   - name: 'postdeploy'
     icon: '🦺️'
-

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -306,7 +306,7 @@ class Kubernetes:
     job: Optional[Job]
     image_pull_secrets: dict
     role: Optional[dict]
-    cmd: Optional[TargetProperty[str]]
+    command: Optional[TargetProperty[str]]
     args: Optional[TargetProperty[str]]
     labels: Optional[list[KeyValueProperty]]
 
@@ -321,7 +321,7 @@ class Kubernetes:
             job=Job.from_config(values.get("job", {})),
             image_pull_secrets=values.get("imagePullSecrets", {}),
             role=values.get("role"),
-            cmd=TargetProperty.from_config(values.get("cmd", {})),
+            command=TargetProperty.from_config(values.get("cmd", {})),
             args=TargetProperty.from_config(values.get("args", {})),
             labels=list(map(KeyValueProperty.from_config, values.get("labels", []))),
         )

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -297,22 +297,6 @@ class Job:
 
 
 @dataclass(frozen=True)
-class Role:
-    resources: list[str]
-    verbs: list[str]
-
-    @staticmethod
-    def from_config(values: dict):
-        if not values:
-            return None
-        resources = values.get("resources")
-        verbs = values.get("verbs")
-        if not resources or not verbs:
-            raise KeyError("Role must have resources and verbs set.")
-        return Role(resources, verbs)
-
-
-@dataclass(frozen=True)
 class Kubernetes:
     port_mappings: dict[int, int]
     liveness_probe: Optional[Probe]
@@ -321,7 +305,7 @@ class Kubernetes:
     resources: Resources
     job: Optional[Job]
     image_pull_secrets: dict
-    role: Optional[Role]
+    role: Optional[dict]
     cmd: Optional[TargetProperty[str]]
     args: Optional[TargetProperty[str]]
     labels: Optional[list[KeyValueProperty]]
@@ -336,7 +320,7 @@ class Kubernetes:
             resources=Resources.from_config(values.get("resources", {})),
             job=Job.from_config(values.get("job", {})),
             image_pull_secrets=values.get("imagePullSecrets", {}),
-            role=Role.from_config(values.get("role", {})),
+            role=values.get("role"),
             cmd=TargetProperty.from_config(values.get("cmd", {})),
             args=TargetProperty.from_config(values.get("args", {})),
             labels=list(map(KeyValueProperty.from_config, values.get("labels", []))),

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -321,12 +321,10 @@ class Kubernetes:
     resources: Resources
     job: Optional[Job]
     image_pull_secrets: dict
-
     role: Optional[Role]
     cmd: Optional[TargetProperty[str]]
     args: Optional[TargetProperty[str]]
     labels: Optional[list[KeyValueProperty]]
-    policies: Optional[list[str]]
 
     @staticmethod
     def from_config(values: dict):
@@ -342,7 +340,6 @@ class Kubernetes:
             cmd=TargetProperty.from_config(values.get("cmd", {})),
             args=TargetProperty.from_config(values.get("args", {})),
             labels=list(map(KeyValueProperty.from_config, values.get("labels", []))),
-            policies=values.get("policies"),
         )
 
 

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -297,6 +297,22 @@ class Job:
 
 
 @dataclass(frozen=True)
+class Role:
+    resources: list[str]
+    verbs: list[str]
+
+    @staticmethod
+    def from_config(values: dict):
+        if not values:
+            return None
+        resources = values.get("resources")
+        verbs = values.get("verbs")
+        if not resources or not verbs:
+            raise KeyError("Role must have resources and verbs set.")
+        return Role(resources, verbs)
+
+
+@dataclass(frozen=True)
 class Kubernetes:
     port_mappings: dict[int, int]
     liveness_probe: Optional[Probe]
@@ -305,6 +321,12 @@ class Kubernetes:
     resources: Resources
     job: Optional[Job]
     image_pull_secrets: dict
+
+    role: Optional[Role]
+    cmd: Optional[TargetProperty[str]]
+    args: Optional[TargetProperty[str]]
+    labels: Optional[list[KeyValueProperty]]
+    policies: Optional[list[str]]
 
     @staticmethod
     def from_config(values: dict):
@@ -316,6 +338,11 @@ class Kubernetes:
             resources=Resources.from_config(values.get("resources", {})),
             job=Job.from_config(values.get("job", {})),
             image_pull_secrets=values.get("imagePullSecrets", {}),
+            role=Role.from_config(values.get("role", {})),
+            cmd=TargetProperty.from_config(values.get("cmd", {})),
+            args=TargetProperty.from_config(values.get("args", {})),
+            labels=list(map(KeyValueProperty.from_config, values.get("labels", []))),
+            policies=values.get("policies"),
         )
 
 

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -321,7 +321,7 @@ class Kubernetes:
             job=Job.from_config(values.get("job", {})),
             image_pull_secrets=values.get("imagePullSecrets", {}),
             role=values.get("role"),
-            command=TargetProperty.from_config(values.get("cmd", {})),
+            command=TargetProperty.from_config(values.get("command", {})),
             args=TargetProperty.from_config(values.get("args", {})),
             labels=list(map(KeyValueProperty.from_config, values.get("labels", []))),
         )

--- a/src/mpyl/projects/versioning.py
+++ b/src/mpyl/projects/versioning.py
@@ -112,6 +112,18 @@ class Upgrader(ABC):
         return previous_dict
 
 
+class ProjectUpgraderOne31(Upgrader):
+    target_version = "1.3.1"
+
+    def upgrade(self, previous_dict: ordereddict) -> ordereddict:
+        if deployment := previous_dict.get("deployment", {}):
+            if kubernetes := deployment.get("kubernetes", {}):
+                if kubernetes.get("cmd", None):
+                    kubernetes["command"] = kubernetes.pop("cmd")
+
+        return previous_dict
+
+
 class ProjectUpgraderOne11(Upgrader):
     target_version = "1.0.11"
 
@@ -150,6 +162,7 @@ PROJECT_UPGRADERS = [
     ProjectUpgraderOne9(),
     ProjectUpgraderOne10(),
     ProjectUpgraderOne11(),
+    ProjectUpgraderOne31(),
 ]
 
 

--- a/src/mpyl/projects/versioning.py
+++ b/src/mpyl/projects/versioning.py
@@ -116,11 +116,9 @@ class ProjectUpgraderOne31(Upgrader):
     target_version = "1.3.1"
 
     def upgrade(self, previous_dict: ordereddict) -> ordereddict:
-        if deployment := previous_dict.get("deployment", {}):
-            if kubernetes := deployment.get("kubernetes", {}):
-                if kubernetes.get("cmd", None):
-                    kubernetes["command"] = kubernetes.pop("cmd")
-
+        if kubernetes := previous_dict.get("deployment", {}).get("kubernetes", {}):
+            if "cmd" in kubernetes:
+                kubernetes["command"] = kubernetes.pop("cmd")
         return previous_dict
 
 

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -39,7 +39,7 @@ from ...steps.run import RunResult
 
 
 @dataclass(frozen=True)
-class JiraTicket:  # pylint: disable = too-many-instance-attributes
+class JiraTicket:
     jira_url: str
     ticket_id: str
     ticket_url: str

--- a/src/mpyl/schema/k8s_api_core.schema.yml
+++ b/src/mpyl/schema/k8s_api_core.schema.yml
@@ -100,3 +100,46 @@ definitions:
         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         type: string
     type: object
+  io.k8s.api.rbac.v1.PolicyRule:
+    description: PolicyRule holds information that describes a policy rule, but does
+      not contain information about who the rule applies to or which namespace the
+      rule applies to.
+    required:
+      - verbs
+    properties:
+      apiGroups:
+        description: APIGroups is the name of the APIGroup that contains the resources.  If
+          multiple API groups are specified, any action requested against one of the
+          enumerated resources in any API group will be allowed.
+        type: array
+        items:
+          type: string
+      nonResourceURLs:
+        description: NonResourceURLs is a set of partial urls that a user should have
+          access to.  *s are allowed, but only as the full, final step in the path
+          Since non-resource URLs are not namespaced, this field is only applicable
+          for ClusterRoles referenced from a ClusterRoleBinding. Rules can either
+          apply to API resources (such as "pods" or "secrets") or non-resource URL
+          paths (such as "/api"),  but not both.
+        type: array
+        items:
+          type: string
+      resourceNames:
+        description: ResourceNames is an optional white list of names that the rule
+          applies to.  An empty set means that everything is allowed.
+        type: array
+        items:
+          type: string
+      resources:
+        description: Resources is a list of resources this rule applies to.  ResourceAll
+          represents all resources.
+        type: array
+        items:
+          type: string
+      verbs:
+        description: Verbs is a list of Verbs that apply to ALL the ResourceKinds
+          and AttributeRestrictions contained in this rule.  VerbAll represents all
+          kinds.
+        type: array
+        items:
+          type: string

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -868,31 +868,7 @@ definitions:
                 description: 'MainFile is the path to a bundled JAR, Python, or R file of the application.'
                 type: string
       role:
-        type: object
-        additionalProperties: false
-        required:
-          - resources
-          - verbs
-        properties:
-          resources:
-            description: >-
-              A list of Kubernetes resources that the verbs will be applied
-              on. See
-              https://kubernetes.io/docs/reference/kubectl/overview/#resource-types
-            type: array
-            minItems: 1
-            items:
-              type: string
-          verbs:
-            description: >-
-              A list of Kubernetes Request Verbs that will be granted to a
-              Role that will be bound to the ServiceAccount of this service.
-              See
-              https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb
-            type: array
-            minItems: 1
-            items:
-              type: string
+        $ref: 'k8s_api_core.schema.yml#/definitions/io.k8s.api.rbac.v1.PolicyRule'
       metrics:
         description: >-
           Prometheus metrics. Requires prometheus operator to be installed.

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -754,7 +754,7 @@ definitions:
           network request inside the container. Containers that fail the
           check are restarted.
         $ref: '#/definitions/livenessProbe'
-      cmd:
+      command:
         $ref: '#/definitions/dtapValue'
       args:
         type: object

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -689,6 +689,11 @@ class ChartBuilder:
                 if self.project.kubernetes.cmd
                 else None
             ),
+            args=(
+                self.project.kubernetes.cmd.get_value(self.target).split(" ")
+                if self.project.kubernetes.args
+                else None
+            ),
         )
 
         instances = resources.instances if resources.instances else defaults.instances

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -725,7 +725,7 @@ class ChartBuilder:  # pylint: disable = too-many-instance-attributes
 
         if self.role:
             chart["role"] = self.to_role(self.role)
-            chart["role-binding"] = self.to_role_binding()
+            chart["rolebinding"] = self.to_role_binding()
 
         return chart
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -690,7 +690,7 @@ class ChartBuilder:
                 else None
             ),
             args=(
-                self.project.kubernetes.cmd.get_value(self.target).split(" ")
+                self.project.kubernetes.args.get_value(self.target).split(" ")
                 if self.project.kubernetes.args
                 else None
             ),

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -507,7 +507,9 @@ class ChartBuilder:
             api_version="rbac.authorization.k8s.io/v1",
             kind="Role",
             metadata=self._to_object_meta(),
-            rules=[ChartBuilder._to_k8s_model(role, V1PolicyRule)],
+            rules=[
+                ChartBuilder._to_k8s_model({"apiGroups": [""]} | role, V1PolicyRule)
+            ],
         )
 
     def to_role_binding(self) -> V1RoleBinding:

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -685,6 +685,11 @@ class ChartBuilder:
             ),
             liveness_probe=liveness_probe,
             startup_probe=startup_probe,
+            command=(
+                self.project.kubernetes.cmd.get_value(self.target).split(" ")
+                if self.project.kubernetes.cmd
+                else None
+            ),
         )
 
         instances = resources.instances if resources.instances else defaults.instances

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -685,8 +685,8 @@ class ChartBuilder:
             liveness_probe=liveness_probe,
             startup_probe=startup_probe,
             command=(
-                self.project.kubernetes.cmd.get_value(self.target).split(" ")
-                if self.project.kubernetes.cmd
+                self.project.kubernetes.command.get_value(self.target).split(" ")
+                if self.project.kubernetes.command
                 else None
             ),
             args=(

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -77,7 +77,6 @@ from ....project import (
     Alert,
     KeyValueRef,
     Metrics,
-    Role,
 )
 from ....stages.discovery import DeploySet
 from ....utilities.docker import DockerImageSpec
@@ -170,7 +169,7 @@ class ChartBuilder:
     config_defaults: DeploymentDefaults
     deploy_set: Optional[DeploySet]
     namespace: str
-    role: Optional[Role]
+    role: Optional[dict]
 
     def __init__(self, step_input: Input, deploy_set: Optional[DeploySet] = None):
         self.step_input = step_input
@@ -503,12 +502,12 @@ class ChartBuilder:
             image_pull_secrets=secrets,
         )
 
-    def to_role(self, role: Role) -> V1Role:
+    def to_role(self, role: dict) -> V1Role:
         return V1Role(
             api_version="rbac.authorization.k8s.io/v1",
             kind="Role",
             metadata=self._to_object_meta(),
-            rules=[V1PolicyRule(resources=role.resources, verbs=role.verbs)],
+            rules=[ChartBuilder._to_k8s_model(role, V1PolicyRule)],
         )
 
     def to_role_binding(self) -> V1RoleBinding:

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -199,7 +199,7 @@ class ChartBuilder:
         self.namespace = get_namespace(
             run_properties=step_input.run_properties, project=project
         )
-        self.role = project.deployment.kubernetes.role
+        self.role = project.kubernetes.role
 
     def _to_labels(self) -> dict:
         run_properties = self.step_input.run_properties

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -157,7 +157,7 @@ class DeploymentDefaults:
         )
 
 
-class ChartBuilder:  # pylint: disable = too-many-instance-attributes
+class ChartBuilder:
     step_input: Input
     project: Project
     mappings: dict[int, int]

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -377,6 +377,7 @@ class ChartBuilder:
                 project_name=self.release_name,
                 env_vars=get_env_variables(self.project, self.target),
                 spark=self._get_job().spark,
+                image=self._get_image(),
             ),
         )
 

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -8,7 +8,7 @@ from kubernetes.client import V1ObjectMeta
 from .. import CustomResourceDefinition
 
 
-def to_spark_body(project_name: str, env_vars: dict, spark: dict) -> dict:
+def to_spark_body(project_name: str, env_vars: dict, spark: dict, image: str) -> dict:
     static_body = {
         "type": "Scala",
         "mode": "cluster",
@@ -16,7 +16,7 @@ def to_spark_body(project_name: str, env_vars: dict, spark: dict) -> dict:
         "sparkVersion": "3.1.1",
         "restartPolicy": {"type": "Never"},
         "sparkConfigMap": project_name,
-        "image": "bigdataregistry.azurecr.io/send-slack-notification:PR-1231",
+        "image": image,
         "arguments": [
             "python",
             "-m",

--- a/tests/projects/test_versioning.py
+++ b/tests/projects/test_versioning.py
@@ -62,8 +62,8 @@ class TestVersioning:
 
     def test_upgraded_should_match_test_config(self):
         assert_roundtrip(
-            self.test_resources_path / "test_project.yml",
-            (self.upgrades_path / self.latest_release_file).read_text("utf-8"),
+            self.upgrades_path / self.latest_release_file,
+            (self.test_resources_path / "test_project.yml").read_text("utf-8"),
         )
 
     def test_full_config_upgrade(self):

--- a/tests/projects/test_versioning.py
+++ b/tests/projects/test_versioning.py
@@ -14,6 +14,7 @@ from src.mpyl.projects.versioning import (
     Upgrader,
     CONFIG_UPGRADERS,
     PROPERTIES_UPGRADERS,
+    ProjectUpgraderOne31,
 )
 from src.mpyl.utilities.yaml import yaml_to_string
 from tests.test_resources.test_data import assert_roundtrip
@@ -51,6 +52,13 @@ class TestVersioning:
             self.upgrades_path / "test_project_1_0_9.yml",
             self.upgrades_path / "test_project_1_0_10.yml",
             [ProjectUpgraderOne9(), ProjectUpgraderOne10()],
+        )
+
+    def test_cmd_replace(self):
+        self.__roundtrip(
+            self.upgrades_path / "test_project_1_0_11.yml",
+            self.upgrades_path / "test_project_1_3_1.yml",
+            [ProjectUpgraderOne10(), ProjectUpgraderOne31()],
         )
 
     def test_full_upgrade(self):

--- a/tests/projects/test_versioning.py
+++ b/tests/projects/test_versioning.py
@@ -25,7 +25,7 @@ class TestVersioning:
     test_resources_path = root_test_path / "test_resources"
     upgrades_path = test_resources_path / "upgrades"
     diff_path = upgrades_path / "diff"
-    latest_release_file = "test_project_1_0_11.yml"
+    latest_release_file = "test_project_1_3_1.yml"
 
     @staticmethod
     def __roundtrip(
@@ -68,7 +68,7 @@ class TestVersioning:
             PROJECT_UPGRADERS,
         )
 
-    def test_upgraded_should_match_test_config(self):
+    def test_upgraded_should_match_test_project(self):
         assert_roundtrip(
             self.upgrades_path / self.latest_release_file,
             (self.test_resources_path / "test_project.yml").read_text("utf-8"),

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -41,7 +41,10 @@ spec:
       name: dockertest
     spec:
       containers:
-      - env:
+      - command:
+        - script.sh
+        - --opt
+        env:
         - name: SOME_ENV
           value: PullRequest
         - name: WITH_NAMESPACE

--- a/tests/steps/deploy/k8s/chart/templates/service/role.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest
+rules:
+- resources:
+  - pods
+  verbs:
+  - list
+  - get

--- a/tests/steps/deploy/k8s/chart/templates/service/rolebinding.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/rolebinding.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dockertest
+subjects:
+- kind: ServiceAccount
+  name: dockertest
+  namespace: pr-1234

--- a/tests/steps/deploy/k8s/chart/templates/spark/role.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/role.yaml
@@ -2,21 +2,25 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    name: dockertest
+    name: sparkjob
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: dockertest
-    app.kubernetes.io/instance: dockertest
+    app.kubernetes.io/name: sparkjob
+    app.kubernetes.io/instance: sparkjob
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest
+  name: sparkjob
 rules:
 - apiGroups:
   - ''
   resources:
   - pods
+  - configmaps
   verbs:
-  - list
   - get
+  - watch
+  - create
+  - list
+  - delete

--- a/tests/steps/deploy/k8s/chart/templates/spark/rolebinding.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/rolebinding.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: sparkjob
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: sparkjob
+    app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: sparkjob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sparkjob
+subjects:
+- kind: ServiceAccount
+  name: sparkjob
+  namespace: pr-1234

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -12,7 +12,7 @@ spec:
     restartPolicy:
       type: Never
     sparkConfigMap: sparkjob
-    image: bigdataregistry.azurecr.io/send-slack-notification:PR-1231
+    image: registry/image:123
     arguments:
     - python
     - -m

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -31,6 +31,52 @@ spec:
   encryptedData:
     SOME_SEALED_SECRET_ENV: AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg==
 ---
+# role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest
+rules:
+- resources:
+  - pods
+  verbs:
+  - list
+  - get
+---
+# rolebinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dockertest
+subjects:
+- kind: ServiceAccount
+  name: dockertest
+  namespace: pr-1234
+---
 # deployment
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -47,7 +47,9 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest
 rules:
-- resources:
+- apiGroups:
+  - ''
+  resources:
   - pods
   verbs:
   - list

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -121,7 +121,10 @@ spec:
       name: dockertest
     spec:
       containers:
-      - env:
+      - command:
+        - script.sh
+        - --opt
+        env:
         - name: SOME_ENV
           value: PullRequest
         - name: WITH_NAMESPACE

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -159,6 +159,8 @@ class TestKubernetesChart:
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
             "service-monitor",
+            "role",
+            "rolebinding",
         ],
     )
     def test_service_chart_roundtrip(self, template):
@@ -175,6 +177,8 @@ class TestKubernetesChart:
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
             "service-monitor",
+            "role",
+            "rolebinding",
         }
 
     def test_service_manifest_roundtrip(self):

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -236,7 +236,10 @@ class TestKubernetesChart:
         chart = to_cron_job_chart(builder)
         self._roundtrip(self.template_path / "cronjob", "cronjob", chart)
 
-    @pytest.mark.parametrize("template", ["spark", "service-account", "config-map"])
+    @pytest.mark.parametrize(
+        "template",
+        ["spark", "service-account", "config-map", "role", "rolebinding"],
+    )
     def test_spark_chart_roundtrip(self, template):
         builder = self._get_builder(get_spark_project())
         chart = to_spark_job_chart(builder)

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -5,7 +5,7 @@ stages:
   test: Docker Test
   deploy: Kubernetes Deploy
   postdeploy: Cypress Test
-mpylVersion: 1.0.10
+mpylVersion: 1.3.1
 maintainer: ['MPyL']
 build:
   args:
@@ -62,8 +62,6 @@ deployment:
       verbs:
         - "list"
         - "get"
-    cmd:
-      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health
@@ -95,6 +93,8 @@ deployment:
           all: 0.2
         mem:
           all: 256
+    command:
+      all: "script.sh --opt"
   traefik:
     hosts:
       - host:

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -62,6 +62,8 @@ deployment:
       verbs:
         - "list"
         - "get"
+    cmd:
+      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -56,6 +56,12 @@ deployment:
             divisor: 0.5
             resource: limits.memory
   kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/upgrades/test_project_1_0_10.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_10.yml
@@ -56,6 +56,14 @@ deployment:
             divisor: 0.5
             resource: limits.memory
   kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
+    cmd:
+      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/upgrades/test_project_1_0_11.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_11.yml
@@ -56,6 +56,14 @@ deployment:
             divisor: 0.5
             resource: limits.memory
   kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
+    cmd:
+      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/upgrades/test_project_1_0_8.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_8.yml
@@ -54,6 +54,14 @@ deployment:
             divisor: 0.5
             resource: limits.memory
   kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
+    cmd:
+      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/upgrades/test_project_1_0_9.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_9.yml
@@ -55,6 +55,14 @@ deployment:
             divisor: 0.5
             resource: limits.memory
   kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
+    cmd:
+      all: "script.sh --opt"
     livenessProbe:
       path:
         all: /health

--- a/tests/test_resources/upgrades/test_project_1_3_1.yml
+++ b/tests/test_resources/upgrades/test_project_1_3_1.yml
@@ -1,0 +1,126 @@
+name: 'dockertest'
+description: 'This is a test container. For testing the MPL pipelines, not to be deployed anywhere.'
+stages:
+  build: Docker Build
+  test: Docker Test
+  deploy: Kubernetes Deploy
+  postdeploy: Cypress Test
+mpylVersion: 1.3.1
+maintainer: ['MPyL']
+build:
+  args:
+    plain:
+      - key: SOME_ENV
+        test: "Test"
+        acceptance: "Acceptance"
+        production: "Production"
+dependencies:
+  build:
+    - 'test/docker/'
+  postdeploy:
+    - 'specs/*.js'
+deployment:
+  namespace: 'dockertest'
+  properties:
+    env:
+      - key: SOME_ENV
+        pr: "PullRequest"
+        test: "Test"
+        acceptance: "Acceptance"
+        production: "Production"
+      - key: PROD_ONLY_ENV
+        production: "Production"
+      - key: WITH_NAMESPACE
+        all: "minimalService.{namespace}.svc.cluster.local"
+    sealedSecret:
+      - key: SOME_SEALED_SECRET_ENV
+        pr: "AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg=="
+        test: "AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg=="
+        acceptance: "Acceptance"
+        production: "Production"
+    kubernetes:
+      - key: SOME_SECRET_ENV
+        valueFrom:
+          secretKeyRef:
+            name: some-secret-name
+            key: password
+            optional: false
+      - key: KUBERNETES_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      - key: RESOURCE_FIELD_REFERENCE
+        valueFrom:
+          resourceFieldRef:
+            containerName: 'minimalService'
+            divisor: 0.5
+            resource: limits.memory
+  kubernetes:
+    role:
+      resources:
+        - "pods"
+      verbs:
+        - "list"
+        - "get"
+    livenessProbe:
+      path:
+        all: /health
+      successThreshold: 0
+      failureThreshold: 99
+      grpc:
+        port: 123
+        service: 'grpcService'
+    portMappings:
+      8080: 80
+    metrics:
+      enabled: true
+      alerts:
+        - name: 'ServiceError'
+          expr: 'true'
+          forDuration: '1m'
+          description: 'Service has encountered errors'
+          severity: 'warning'
+    resources:
+      instances:
+        all: 3
+      limit:
+        cpus:
+          all: 0.5
+        mem:
+          all: 1024
+      request:
+        cpus:
+          all: 0.2
+        mem:
+          all: 256
+    command:
+      all: "script.sh --opt"
+  traefik:
+    hosts:
+      - host:
+          pr: "Host(`payments-{PR-NUMBER}.test.nl`)"
+          test: "Host(`payments.test.nl`)"
+          acceptance: "Host(`payments.acceptance1.nl`)"
+          production: "Host(`payments.nl`)"
+        tls:
+          all: "le-custom-prod-wildcard-cert"
+        insecure: true
+        whitelists:
+          test:
+            - "Test"
+      - host:
+          all: "Host(`some.other.host.com`)"
+        servicePort: 4091
+        priority: 1000
+        whitelists:
+          pr:
+            - "K8s-Test"
+            - "VPN"
+          test:
+            - "K8s-Test"
+            - "VPN"
+          acceptance:
+            - "VPN"
+          production:
+            - "Outside-World"
+


### PR DESCRIPTION
- [x] Add role and rolebinding
- [x] Add cmd and args
- [ ] Add labels
- [x] Rename cmd -> command to match k8s
- [x] Add project yaml upgrader for cmd
- [x] Backport it to mpl: PR https://github.com/Vandebron/mpl-modules/pull/428

----
### 📕 [TECH-630](https://vandebron.atlassian.net/browse/TECH-630) Fix missing kubernetes fields <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-265/5/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-265.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-265.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-265.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-630]: https://vandebron.atlassian.net/browse/TECH-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ