### PR TITLE
[TECH-546] Lint whitelisting rules

### DIFF
--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -144,7 +144,7 @@ def _lint_whitelisting_rules(
     target: Target,
 ):
     console.print("")
-    console.print("Checking whitelisting rules: ")
+    console.print(f"Checking whitelisting rules for target {target}: ")
     defined_whitelists: set[str] = set(
         map(lambda rule: rule["name"], config["whiteLists"]["addresses"])
     )

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -148,26 +148,25 @@ def _lint_whitelisting_rules(
     defined_whitelists: set[str] = set(
         map(lambda rule: rule["name"], config["whiteLists"]["addresses"])
     )
-    projects_with_traefik_config = [
-        p for p in projects if p.deployment and p.deployment.traefik
-    ]
     wrong_whitelists: list[tuple[Project, set]] = []
-    for project in projects_with_traefik_config:
-        whitelists: set[str] = set(
-            itertools.chain.from_iterable(
-                [
-                    whitelist_property.get_value(target)
-                    for whitelist_property in [
-                        host.whitelists
-                        for host in project.deployment.traefik.hosts
-                        if host.whitelists is not None
-                    ]
-                    if whitelist_property.get_value(target) is not None
-                ]
-            )
-        )
-        if diff := whitelists.difference(defined_whitelists):
-            wrong_whitelists.append((project, diff))
+    for project in projects:
+        if project.deployment:
+            if traefik := project.deployment.traefik:
+                whitelists: set[str] = set(
+                    itertools.chain.from_iterable(
+                        [
+                            whitelist_property.get_value(target)
+                            for whitelist_property in [
+                                host.whitelists
+                                for host in traefik.hosts
+                                if host.whitelists is not None
+                            ]
+                            if whitelist_property.get_value(target) is not None
+                        ]
+                    )
+                )
+                if diff := whitelists.difference(defined_whitelists):
+                    wrong_whitelists.append((project, diff))
     if len(wrong_whitelists) == 0:
         console.print("  ✅ No undefined whitelists found")
     else:

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -171,6 +171,4 @@ def _lint_whitelisting_rules(
         console.print("  ✅ No undefined whitelists found")
     else:
         for project, diff in wrong_whitelists:
-            console.log(
-                f'  ❌ Project "{project.name}" has undefined whitelists: {diff}'
-            )
+            console.log(f"  ❌ Project {project.name} has undefined whitelists: {diff}")

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -148,25 +148,26 @@ def _lint_whitelisting_rules(
     defined_whitelists: set[str] = set(
         map(lambda rule: rule["name"], config["whiteLists"]["addresses"])
     )
+    projects_with_traefik_config = [
+        p for p in projects if p.deployment and p.deployment.traefik
+    ]
     wrong_whitelists: list[tuple[Project, set]] = []
-    for project in projects:
-        if project.deployment:
-            if traefik := project.deployment.traefik:
-                whitelists: set[str] = set(
-                    itertools.chain.from_iterable(
-                        [
-                            whitelist_property.get_value(target)
-                            for whitelist_property in [
-                                host.whitelists
-                                for host in traefik.hosts
-                                if host.whitelists is not None
-                            ]
-                            if whitelist_property.get_value(target) is not None
-                        ]
-                    )
-                )
-                if diff := whitelists.difference(defined_whitelists):
-                    wrong_whitelists.append((project, diff))
+    for project in projects_with_traefik_config:
+        whitelists: set[str] = set(
+            itertools.chain.from_iterable(
+                [
+                    whitelist_property.get_value(target)
+                    for whitelist_property in [
+                        host.whitelists
+                        for host in project.deployment.traefik.hosts
+                        if host.whitelists is not None
+                    ]
+                    if whitelist_property.get_value(target) is not None
+                ]
+            )
+        )
+        if diff := whitelists.difference(defined_whitelists):
+            wrong_whitelists.append((project, diff))
     if len(wrong_whitelists) == 0:
         console.print("  ✅ No undefined whitelists found")
     else:

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -20,6 +20,7 @@ from ..cli.commands.projects.lint import (
     _check_and_load_projects,
     _assert_unique_project_names,
     _assert_correct_project_linkup,
+    _lint_whitelisting_rules,
 )
 from ..cli.commands.projects.upgrade import check_upgrade
 from ..constants import DEFAULT_CONFIG_FILE_NAME
@@ -130,7 +131,7 @@ def show_project(ctx, name):
     "-e",
     "extended",
     is_flag=True,
-    help="Enable extra validations like PR namespace linkup",
+    help="Enable extra validations like PR namespace linkup or whitelisting rules check",
 )
 @click.pass_obj
 def lint(obj: ProjectsContext, extended):
@@ -155,12 +156,20 @@ def lint(obj: ProjectsContext, extended):
         all_projects=all_projects,
     )
     if extended:
+        obj.cli.console.print("")
+        obj.cli.console.print("Running extended checks...")
         _assert_correct_project_linkup(
             console=obj.cli.console,
             target=Target.PULL_REQUEST,
             projects=loaded_projects,
             all_projects=all_projects,
             pr_identifier=123,
+        )
+        _lint_whitelisting_rules(
+            console=obj.cli.console,
+            projects=loaded_projects,
+            config=obj.cli.config,
+            target=Target.PULL_REQUEST,
         )
 
 

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -169,7 +169,7 @@ def lint(obj: ProjectsContext, extended):
             console=obj.cli.console,
             projects=loaded_projects,
             config=obj.cli.config,
-            target=Target.PULL_REQUEST,  # TODO: lint all targets?
+            target=Target.PULL_REQUEST,  # lint all targets?
         )
 
 

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -169,7 +169,7 @@ def lint(obj: ProjectsContext, extended):
             console=obj.cli.console,
             projects=loaded_projects,
             config=obj.cli.config,
-            target=Target.PULL_REQUEST,
+            target=Target.PULL_REQUEST,  # TODO: lint all targets?
         )
 
 

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -165,12 +165,13 @@ def lint(obj: ProjectsContext, extended):
             all_projects=all_projects,
             pr_identifier=123,
         )
-        _lint_whitelisting_rules(
-            console=obj.cli.console,
-            projects=loaded_projects,
-            config=obj.cli.config,
-            target=Target.PULL_REQUEST,  # lint all targets?
-        )
+        for target in Target:
+            _lint_whitelisting_rules(
+                console=obj.cli.console,
+                projects=loaded_projects,
+                config=obj.cli.config,
+                target=target,
+            )
 
 
 @projects.command(help="Upgrade projects to conform with the latest schema")

--- a/tests/cli/commands/test_cli.py
+++ b/tests/cli/commands/test_cli.py
@@ -45,7 +45,7 @@ class TestCli:
             ["projects", "-c", str(self.config_path), "lint"],
         )
         assert re.match(
-            r"(.|\n)*Validated .* projects\. .* valid, .* invalid\n\n.*No duplicate project names found",
+            r"(.|\n)*Validated .* projects\. .* valid, .* invalid\n\nChecking for duplicate project names: \n.*No duplicate project names found",
             result.output,
         )
 


### PR DESCRIPTION
Lint the whitelisting rules defined in the project yamls when doing `mpyl projects lint --extended`

Monorepo run:

```
Running extended checks...

Checking namespace substitution: 
  ❌ Project batterypackApi has wrong namespace substitutions:
  OCPP_URL references unrecognized project ocpp-master
  ❌ Project chargeCardEcedoSyncJob has wrong namespace substitutions:
  SFSYNC_URL references unrecognized project sfsync (did you mean sfSync?)
  ❌ Project chargePointEcedoSyncJob has wrong namespace substitutions:
  SFSYNC_URL references unrecognized project sfsync (did you mean sfSync?)
  ❌ Project mockservice has wrong namespace substitutions:
  BATTERY_API_URL references unrecognized project batteryApi
  GENERATOR_API_URL references unrecognized project generatorApi
  ❌ Project publicApiVPP has wrong namespace substitutions:
  BATTERY_API_URL references unrecognized project batteryApi

Checking whitelisting rules: 
  ❌ Project "batterypackApi" has undefined whitelists: {'Stripe', 'ECEDO-Office', 'VDB-API', 'Sharewire-Office', 'Blockchain-VM', 'ECEDO', 'Sharewire', 'NAT-Gateway',
'JenkinsBI', 'MSP-Broker'}                                                                                                                                             
  ❌ Project "flexiot" has undefined whitelists: {'VDB-API', 'Sharewire', 'NAT-Gateway', 'JenkinsBI', 'MSP-Broker'}                                                    
  ❌ Project "chargeCardApi" has undefined whitelists: {'Stripe', 'ECEDO-Office', 'VDB-API', 'Sharewire-Office', 'Blockchain-VM', 'ECEDO', 'Sharewire', 'NAT-Gateway', 
'JenkinsBI', 'MSP-Broker'}                                                                                                                                             
  ❌ Project "acceptanceEmailConnectorProxy" has undefined whitelists: {'JenkinsBI'}                                                                                   
  ❌ Project "testEmailConnectorProxy" has undefined whitelists: {'JenkinsBI'}                                                                                         
  ❌ Project "messageCreator" has undefined whitelists: {'JenkinsBI'}                                                                                                  
  ❌ Project "messageStoreApi" has undefined whitelists: {'JenkinsBI'}                                                                                                 
  ❌ Project "tradingMockServiceApi" has undefined whitelists: {'JenkinsBI'}                                                                                           
  ❌ Project "calculatePositionDataService" has undefined whitelists: {'JenkinsBI'}                                                                                    
  ❌ Project "tradeStoreApi" has undefined whitelists: {'JenkinsBI'}                                                                                                   
  ❌ Project "payment" has undefined whitelists: {'Stripe'}                                                                                                            
  ❌ Project "sfSync" has undefined whitelists: {'Stripe', 'ECEDO-Office', 'VDB-API', 'Sharewire-Office', 'Blockchain-VM', 'ECEDO', 'Sharewire', 'NAT-Gateway',        
'JenkinsBI', 'MSP-Broker'}                                                                                                                                             
  ❌ Project "keycloak" has undefined whitelists: {'ECEDO', 'NAT-Gateway-Kubernetes'}                                                                                  
  ❌ Project "meterreadingApi" has undefined whitelists: {'Stripe', 'ECEDO-Office', 'VDB-API', 'Sharewire-Office', 'Blockchain-VM', 'ECEDO', 'Sharewire',              
'NAT-Gateway', 'JenkinsBI', 'MSP-Broker'}                                                                                                                              
  ❌ Project "curtailmentFleet" has undefined whitelists: {'Stripe', 'ECEDO-Office', 'VDB-API', 'Sharewire-Office', 'Blockchain-VM', 'ECEDO', 'Sharewire',             
'NAT-Gateway', 'JenkinsBI', 'MSP-Broker'} 
```

----
### 📕 [TECH-546](https://vandebron.atlassian.net/browse/TECH-546) Lint whitelisting rules <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Add a rule to the linting command so that the list of whitelisting rules in the project yaml are matched against the mpyl config’s whitelist

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-269/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-269.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-269.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-269.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-546]: https://vandebron.atlassian.net/browse/TECH-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ