### PR TITLE
feature/TECH 634 target specific whitelists

### DIFF
--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -62,11 +62,16 @@ whiteLists:
   default: [ "VPN" ]
   addresses:
     - name: "VPN"
-      values: [ "10.0.0.1" ]
+      all: [ "10.0.0.1" ]
     - name: 'Outside-World'
-      values: [ '0.0.0.0/0' ]
+      all: [ '0.0.0.0/0' ]
     - name: 'K8s-Test'
-      values: [ '1.2.3.0', '1.2.3.1' ]
+      all: [ '1.2.3.0', '1.2.3.1' ]
+    - name: 'TargetSpecificWhitelist'
+      pr: ['1.2.3.4']
+      test: ['1.2.3.4']
+      acceptance: ['2.3.4.5']
+      production: ['3.4.5.6']
 kubernetes:
   deployAction: KubectlManifest
   rancher:

--- a/releases/notes/1.3.1.md
+++ b/releases/notes/1.3.1.md
@@ -1,7 +1,7 @@
 #### Target specific whitelists
 
 Now have the possiblity to specify target specific whitelisting rules.
-This means that for the same rule, we can apply different list of IPs, depending on the target environemnt:
+This means that for the same rule, we can apply different lists of IPs, depending on the target environment:
 Change in the `mpyl_config.yaml` file:
 
 ```yaml

--- a/releases/notes/1.3.1.md
+++ b/releases/notes/1.3.1.md
@@ -20,3 +20,8 @@ whiteLists:
       acceptance: ['2.3.4.5']
       production: ['3.4.5.6']
 ```
+
+#### Add support for various kubernetes resources
+
+- Add support for `Role` and `RoleBinding` resources
+- Be able to specify `command` and `args` in `Container` resources

--- a/releases/notes/1.3.1.md
+++ b/releases/notes/1.3.1.md
@@ -1,0 +1,22 @@
+#### Target specific whitelists
+
+Now have the possiblity to specify target specific whitelisting rules.
+This means that for the same rule, we can apply different list of IPs, depending on the target environemnt:
+Change in the `mpyl_config.yaml` file:
+
+```yaml
+whiteLists:
+  default: [ "VPN" ]
+  addresses:
+    - name: "VPN"
+      all: [ "10.0.0.1" ]
+    - name: 'Outside-World'
+      all: [ '0.0.0.0/0' ]
+    - name: 'K8s-Test'
+      all: [ '1.2.3.0', '1.2.3.1' ]
+    - name: 'TargetSpecificWhitelist'
+      pr: ['1.2.3.4']
+      test: ['1.2.3.4']
+      acceptance: ['2.3.4.5']
+      production: ['3.4.5.6']
+```

--- a/src/mpyl/projects/versioning.py
+++ b/src/mpyl/projects/versioning.py
@@ -164,6 +164,24 @@ PROJECT_UPGRADERS = [
 ]
 
 
+class ConfigUpgraderOne31(Upgrader):
+    target_version = "1.3.0"
+
+    def upgrade(self, previous_dict: ordereddict) -> ordereddict:
+        whitelists = previous_dict.get("whiteLists", {})
+        existing_addresses = whitelists.get("addresses")
+        if existing_addresses:
+            whitelists.pop("addresses")
+            new_addresses = list(
+                address
+                if address.get("values") is None
+                else {"name": address["name"], "all": address["values"]}
+                for address in existing_addresses
+            )
+            previous_dict["whiteLists"].insert(1, "addresses", new_addresses)
+        return previous_dict
+
+
 class ConfigUpgraderOne30(Upgrader):
     target_version = "1.3.0"
 
@@ -199,7 +217,12 @@ class ConfigUpgraderOne8(Upgrader):
         return previous_dict
 
 
-CONFIG_UPGRADERS = [ConfigUpgraderOne8(), ConfigUpgraderOne9(), ConfigUpgraderOne30()]
+CONFIG_UPGRADERS = [
+    ConfigUpgraderOne8(),
+    ConfigUpgraderOne9(),
+    ConfigUpgraderOne30(),
+    ConfigUpgraderOne31(),
+]
 
 
 class PropertiesUpgraderOne30(Upgrader):

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -58,11 +58,38 @@ definitions:
           additionalProperties: false
           required:
             - name
-            - values
+          oneOf:
+            - required:
+                - pr
+                - test
+                - acceptance
+                - production
+            - required:
+                - all
           properties:
             name:
               type: string
-            values:
+            pr:
+              type: array
+              items:
+                minItems: 1
+                type: string
+            test:
+              type: array
+              items:
+                minItems: 1
+                type: string
+            acceptance:
+              type: array
+              items:
+                minItems: 1
+                type: string
+            production:
+              type: array
+              items:
+                minItems: 1
+                type: string
+            all:
               type: array
               items:
                 minItems: 1

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -213,8 +213,6 @@ class ChartBuilder:
             step_input.run_properties.config
         )
 
-        print(self.config_defaults.white_lists)
-
         self.deployment = project.deployment
         properties = self.deployment.properties
         self.env = properties.env if properties and properties.env else []
@@ -463,7 +461,6 @@ class ChartBuilder:
             address.name: address.host.get_value(self.target)
             for address in configured_addresses
         }
-        print(address_dictionary)
 
         def to_white_list(
             configured: Optional[TargetProperty[list[str]]],

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -454,12 +454,9 @@ class ChartBuilder:
             self.deployment.traefik.hosts if self.deployment.traefik else []
         )
 
-        configured_addresses = [
-            address for address in self.config_defaults.white_lists.addresses
-        ]
         address_dictionary = {
             address.name: address.host.get_value(self.target)
-            for address in configured_addresses
+            for address in self.config_defaults.white_lists.addresses
         }
 
         def to_white_list(

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -130,13 +130,44 @@ class ResourceDefaults:
 
 
 @dataclass(frozen=True)
+class DefaultWhitelistAddress:
+    name: str
+    host: TargetProperty[list[str]]
+
+    @staticmethod
+    def from_config(values: dict):
+        return DefaultWhitelistAddress(
+            name=values["name"],
+            host=TargetProperty.from_config(values),
+        )
+
+
+@dataclass(frozen=True)
+class DefaultWhitelists:
+    default: list[str]
+    addresses: list[DefaultWhitelistAddress]
+
+    @staticmethod
+    def from_config(values: dict):
+        if values is None:
+            return None
+        return DefaultWhitelists(
+            default=values["default"],
+            addresses=[
+                DefaultWhitelistAddress.from_config(address)
+                for address in values["addresses"]
+            ],
+        )
+
+
+@dataclass(frozen=True)
 class DeploymentDefaults:
     resources_defaults: ResourceDefaults
     liveness_probe_defaults: dict
     startup_probe_defaults: dict
     job_defaults: dict
     traefik_defaults: dict
-    white_lists: dict
+    white_lists: DefaultWhitelists
     image_pull_secrets: dict
 
     @staticmethod
@@ -151,7 +182,7 @@ class DeploymentDefaults:
             startup_probe_defaults=kubernetes["startupProbe"],
             job_defaults=kubernetes.get("job", {}),
             traefik_defaults=deployment_values.get("traefik", {}),
-            white_lists=config.get("whiteLists", {}),
+            white_lists=DefaultWhitelists.from_config(config.get("whiteLists", {})),
             image_pull_secrets=kubernetes.get("imagePullSecrets", {}),
         )
 
@@ -181,6 +212,8 @@ class ChartBuilder:
         self.config_defaults = DeploymentDefaults.from_config(
             step_input.run_properties.config
         )
+
+        print(self.config_defaults.white_lists)
 
         self.deployment = project.deployment
         properties = self.deployment.properties
@@ -423,15 +456,19 @@ class ChartBuilder:
             self.deployment.traefik.hosts if self.deployment.traefik else []
         )
 
-        configured_addresses = self.config_defaults.white_lists["addresses"]
+        configured_addresses = [
+            address for address in self.config_defaults.white_lists.addresses
+        ]
         address_dictionary = {
-            address["name"]: address["values"] for address in configured_addresses
+            address.name: address.host.get_value(self.target)
+            for address in configured_addresses
         }
+        print(address_dictionary)
 
         def to_white_list(
             configured: Optional[TargetProperty[list[str]]],
         ) -> dict[str, list[str]]:
-            white_lists = self.config_defaults.white_lists["default"].copy()
+            white_lists = self.config_defaults.white_lists.default
             if configured and configured.get_value(self.target):
                 white_lists.extend(configured.get_value(self.target))
 

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -3,6 +3,8 @@ kind: Middleware
 metadata:
   annotations:
     VPN: 10.0.0.1
+    K8s-Test: 1.2.3.0, 1.2.3.1
+    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -18,3 +20,6 @@ spec:
   ipWhiteList:
     sourceRange:
     - 10.0.0.1
+    - 1.2.3.0
+    - 1.2.3.1
+    - 1.2.3.4

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     VPN: 10.0.0.1
     K8s-Test: 1.2.3.0, 1.2.3.1
+    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -21,3 +22,4 @@ spec:
     - 10.0.0.1
     - 1.2.3.0
     - 1.2.3.1
+    - 1.2.3.4

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -320,6 +320,8 @@ kind: Middleware
 metadata:
   annotations:
     VPN: 10.0.0.1
+    K8s-Test: 1.2.3.0, 1.2.3.1
+    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -335,6 +337,9 @@ spec:
   ipWhiteList:
     sourceRange:
     - 10.0.0.1
+    - 1.2.3.0
+    - 1.2.3.1
+    - 1.2.3.4
 ---
 # dockertest-ingress-1-whitelist
 apiVersion: traefik.containo.us/v1alpha1
@@ -343,6 +348,7 @@ metadata:
   annotations:
     VPN: 10.0.0.1
     K8s-Test: 1.2.3.0, 1.2.3.1
+    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -360,3 +366,4 @@ spec:
     - 10.0.0.1
     - 1.2.3.0
     - 1.2.3.1
+    - 1.2.3.4

--- a/tests/test_resources/mpyl_config.yml
+++ b/tests/test_resources/mpyl_config.yml
@@ -44,11 +44,16 @@ whiteLists:
   default: [ "VPN" ]
   addresses:
     - name: "VPN"
-      values: [ "10.0.0.1" ]
+      all: [ "10.0.0.1" ]
     - name: 'Outside-World'
-      values: [ '0.0.0.0/0' ]
+      all: [ '0.0.0.0/0' ]
     - name: 'K8s-Test'
-      values: [ '1.2.3.0', '1.2.3.1' ]
+      all: [ '1.2.3.0', '1.2.3.1' ]
+    - name: 'TargetSpecificWhitelist'
+      pr: [ '1.2.3.4' ]
+      test: [ '1.2.3.4' ]
+      acceptance: [ '2.3.4.5' ]
+      production: [ '3.4.5.6' ]
 cypress:
   cypressSourceCodePath: 'test_resources/cypress'
 kubernetes:

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -116,6 +116,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"

--- a/tests/test_resources/upgrades/mpyl_config_upgraded.yml
+++ b/tests/test_resources/upgrades/mpyl_config_upgraded.yml
@@ -45,11 +45,11 @@ whiteLists:
   default: ["VPN"]
   addresses:
     - name: "VPN"
-      values: ["10.0.0.1"]
+      all: ["10.0.0.1"]
     - name: 'Outside-World'
-      values: ['0.0.0.0/0']
+      all: ['0.0.0.0/0']
     - name: 'K8s-Test'
-      values: ['1.2.3.0', '1.2.3.1']
+      all: ['1.2.3.0', '1.2.3.1']
 cypress:
   cypressSourceCodePath: 'test_resources/cypress'
 kubernetes:

--- a/tests/test_resources/upgrades/test_project_1_0_10.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_10.yml
@@ -116,6 +116,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"

--- a/tests/test_resources/upgrades/test_project_1_0_11.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_11.yml
@@ -116,6 +116,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"

--- a/tests/test_resources/upgrades/test_project_1_0_8.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_8.yml
@@ -114,6 +114,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"

--- a/tests/test_resources/upgrades/test_project_1_0_9.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_9.yml
@@ -115,6 +115,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"

--- a/tests/test_resources/upgrades/test_project_1_3_1.yml
+++ b/tests/test_resources/upgrades/test_project_1_3_1.yml
@@ -116,6 +116,7 @@ deployment:
           pr:
             - "K8s-Test"
             - "VPN"
+            - "TargetSpecificWhitelist"
           test:
             - "K8s-Test"
             - "VPN"


### PR DESCRIPTION
mpyl config counterpart: https://github.com/Vandebron/mpyl_config/pull/6

- [x] Be able to specify target specific whitelists.

mpyl_config:

```yaml
whiteLists:
  default: [ "VPN" ]
  addresses:
    - name: "VPN"
      all: [ "10.0.0.1" ]
    - name: 'Outside-World'
      all: [ '0.0.0.0/0' ]
    - name: 'K8s-Test'
      all: [ '1.2.3.0', '1.2.3.1' ]
    - name: 'TargetSpecificWhitelist'
      pr: [ '1.2.3.4' ]
      test: [ '1.2.3.4' ]
      acceptance: [ '2.3.4.5' ]
      production: [ '3.4.5.6' ]
```

- [x] create config upgrader

----
### 📕 [TECH-634](https://vandebron.atlassian.net/browse/TECH-634) Add target specific traefik rules <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
Add target specific whitelisting rules to mpyl_config:

```
whiteLists:
  default: ['VPN']
  addresses:
    - name: 'VPN'
      values: ['40.113.125.116']
  targetSpecific:
    - name: 'JenkinsBI'
      pr: ['52.57.213.124', '3.122.18.1', '18.156.186.193']
      test: ['52.57.213.124', '3.122.18.1', '18.156.186.193']
      acceptance: ['52.57.213.124', '3.122.18.1', '18.156.186.193']
      production: ['52.57.213.124', '3.122.18.1', '18.156.186.193']
```

🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-270/5/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-270.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-270.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-270.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-634]: https://vandebron.atlassian.net/browse/TECH-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ