### PR TITLE
[TECH-494] Make tests runnable on Linux

### DIFF
--- a/tests/cli/commands/test_cli.py
+++ b/tests/cli/commands/test_cli.py
@@ -1,4 +1,4 @@
-import os
+import platform
 import re
 
 import pytest
@@ -75,14 +75,16 @@ class TestCli:
             main_group,
             ["version"],
         )
-        regex = r"MPyL \d+\.\d+\.\d+"
-        if "GITHUB_JOB" in os.environ:
+
+        if platform.system() == "Darwin":
+            regex = r"MPyL \d+\.\d+\.\d+"
+        else:
             regex = r"MPyL \(local\)"
 
         assert re.match(regex, result.output)
 
     @pytest.mark.skipif(
-        condition="GITHUB_JOB" in os.environ,
+        condition=platform.system() != "Darwin",
         reason="mpyl distribution is not available in github action",
     )
     def test_verbose_version_print(self):


### PR DESCRIPTION


----
### 📕 [TECH-494](https://vandebron.atlassian.net/browse/TECH-494) Migrate project overrides <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5f7adaf9b61f66006f281ef8/df107e66-dd70-4485-af43-2d25cefbedf7/24" width="24" height="24" alt="nikkashi@vandebron.nl" /> 
**What**

We currently do not support project yaml overrides in MPyL. It is also interfering with the namespace linkup linting step (because the project name is dynamic).

Teams indicated that they are going to migrate some project away from using these overrides, see: [2023-07-26+CI+CD+Guild](https://vandebron.atlassian.net/wiki/spaces/DIG/pages/95581484646441/2023-07-26+CI+CD+Guild) 

For the rest, come up with a plan on how to migrate them, talk to teams that have projects like that.

For argo, take a look at applicationset: [](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/) 

----

**How**

There’s a main project yaml and override yamls. The override yaml should be attached to the main one which create a new project.

Current shortcomings:

* env vars need to be duplicated
* docker images are created multiple times (per override)

The overrides concern the `deployment` section of the project yaml.

Then, when constructing the build plan, the overrides would only be applied to the Deployment stage.

So we’ll have one run of build and test stages, then multiple projects will be deployed from it with different input and environment.

example build plan:

build: `ocpp`

test: `ocpp`

deployment: `ocpp-1}}, {{ocpp-2` , … => should use the same image that was created before

----

figure out a name for this (project merge)

create a schema → subset of the project yaml schema and validate the overridden projects

in MPL overrides were detected by a naming convention: `project-override-XXX.yml}}, the main project has a {{project.yaml`

----

Check out [kustomize](https://kustomize.io/), if it can be applied as after the deployment stage

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-272/2/display/redirect) ✅ Successful, started by _Nik Kashi_  
🚀 *[cloudfront-service](https://cloudfront-service-272.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-272.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-272.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-494]: https://vandebron.atlassian.net/browse/TECH-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ