### PR TITLE
[TECH-435] add dryrun + version flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ pipeline {
                 script {
                     properties([parameters([
                         string(name: 'BUILD_PARAMS', defaultValue: '--all', description: 'Build parameters passed along with the run. Example: --help or --all'),
-                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository')
+                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository'),
+                        string(name: 'MPYL_RELEASE', defaultValue: "${CHANGE_ID}.*", description: 'MPyL version to be installed')
                     ])])
                     currentBuild.result = 'NOT_BUILT'
                     currentBuild.description = "Parameters can be set now"
@@ -39,7 +40,7 @@ pipeline {
                     withKubeConfig([credentialsId: 'jenkins-rancher-service-account-kubeconfig-test']) {
                         wrap([$class: 'BuildUser']) {
                             sh "pipenv clean"
-                            sh "pipenv install --ignore-pipfile --skip-lock --site-packages --index https://test.pypi.org/simple/ 'mpyl==$CHANGE_ID.*'"
+                            sh "pipenv install --ignore-pipfile --skip-lock --site-packages --index https://test.pypi.org/simple/ 'mpyl==${params.MPYL_RELEASE}'"
                             sh "pipenv install -d --skip-lock"
                             sh "pipenv run mpyl version"
                             sh "pipenv run mpyl health --ci --upgrade"

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -67,6 +67,7 @@ def main(log: Logger, args: argparse.Namespace):
         pull_main=True,
         verbose=args.verbose,
         all=args.all,
+        dryrun=args.dry_run,
     )
     run_result = run_mpyl(
         run_properties=run_properties,

--- a/mpyl-example.py
+++ b/mpyl-example.py
@@ -67,7 +67,7 @@ def main(log: Logger, args: argparse.Namespace):
         pull_main=True,
         verbose=args.verbose,
         all=args.all,
-        dryrun=args.dry_run,
+        dryrun=args.dryrun,
     )
     run_result = run_mpyl(
         run_properties=run_properties,

--- a/src/mpyl/cli/__init__.py
+++ b/src/mpyl/cli/__init__.py
@@ -38,6 +38,7 @@ class MpylCliParameters:
     pull_main: bool = False
     verbose: bool = False
     all: bool = False
+    dryrun: bool = False
 
 
 async def get_publication_info(test: bool = False) -> dict:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -311,6 +311,7 @@ def select_version(value: str) -> str:
         )
     return value
 
+
 def select_target():
     return questionary.select(
         "Which environment do you want to deploy to?",

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -27,6 +27,8 @@ class JenkinsRunParameters:
     pipeline_parameters: dict
     verbose: bool
     follow: bool
+    dryrun: bool
+    all: bool
     tag: Optional[str] = None
     tag_target: Target = Target.ACCEPTANCE
 

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -120,7 +120,10 @@ def __execute_install_cmd(
     print("PRINTING HERE", dry_run, JenkinsRunParameters.pipeline_parameters["BUILD_PARAMS"])
 
     cmd = f"helm upgrade -i {chart_name} -n {name_space} --kube-context {kube_context} {additional_args}"
-    if dry_run or "--dryrun" in JenkinsRunParameters.pipeline_parameters["BUILD_PARAMS"]:
+    if (
+            dry_run
+            or "--dryrun" in JenkinsRunParameters.pipeline_parameters["BUILD_PARAMS"]
+    ):
         cmd = (
             f"helm upgrade -i {chart_name} -n namespace --kube-context {kube_context} {additional_args} "
             f"--debug --dry-run"

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -11,6 +11,7 @@ import yaml
 from .resources import to_yaml, CustomResourceDefinition
 from ...models import RunProperties, Output
 from ....cli import get_version
+from ....cli.commands.build.jenkins import JenkinsRunParameters
 from ....utilities.subprocess import custom_check_output
 
 
@@ -115,8 +116,11 @@ def __execute_install_cmd(
     kube_context: str,
     additional_args: str = "",
 ) -> Output:
+
+    print("PRINTING HERE", dry_run, JenkinsRunParameters.pipeline_parameters["BUILD_PARAMS"])
+
     cmd = f"helm upgrade -i {chart_name} -n {name_space} --kube-context {kube_context} {additional_args}"
-    if dry_run:
+    if dry_run or "--dryrun" in JenkinsRunParameters.pipeline_parameters["BUILD_PARAMS"]:
         cmd = (
             f"helm upgrade -i {chart_name} -n namespace --kube-context {kube_context} {additional_args} "
             f"--debug --dry-run"

--- a/tests/cli/commands/test_cli.py
+++ b/tests/cli/commands/test_cli.py
@@ -1,8 +1,10 @@
 import platform
 import re
+import requests
 
 import pytest
 from click.testing import CliRunner
+from packaging import version as packaging_version
 
 from src.mpyl import main_group, add_commands
 from src.mpyl.cli import create_console_logger
@@ -28,6 +30,21 @@ class TestCli:
         result = self.runner.invoke(main_group, ["build", "--help"])
         assert_roundtrip(self.resource_path / "build_help_text.txt", result.output)
 
+    def test_build_jenkins_help_output(self):
+        result = self.runner.invoke(
+            main_group, ["build", "-c", str(self.config_path), "jenkins", "--help"]
+        )
+
+        assert_roundtrip(
+            self.resource_path / "build_jenkins_help_text.txt", result.output
+        )
+
+    def test_get_test_releases(self):
+        response = requests.get("https://test.pypi.org/pypi/mpyl/json", timeout=30)
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data != {"message": "Not Found"}
     def test_build_projects_repo_output(self):
         result = self.runner.invoke(main_group, ["repo", "--help"])
         assert_roundtrip(self.resource_path / "repo_help_text.txt", result.output)

--- a/tests/cli/commands/test_cli.py
+++ b/tests/cli/commands/test_cli.py
@@ -45,6 +45,7 @@ class TestCli:
 
         assert response.status_code == 200
         assert data != {"message": "Not Found"}
+
     def test_build_projects_repo_output(self):
         result = self.runner.invoke(main_group, ["repo", "--help"])
         assert_roundtrip(self.resource_path / "repo_help_text.txt", result.output)

--- a/tests/cli/test_resources/build_jenkins_help_text.txt
+++ b/tests/cli/test_resources/build_jenkins_help_text.txt
@@ -1,0 +1,29 @@
+Usage: mpyl build jenkins [OPTIONS]
+
+  Run a multi branch pipeline build on Jenkins
+
+Options:
+  -u, --user TEXT           Authentication API user. Can be set via env var
+                            JENKINS_USER  [required]
+  -p, --password TEXT       Authentication API password. Can be set via env var
+                            JENKINS_PASSWORD  [required]
+  -pl, --pipeline PIPELINE  The pipeline to run. Must be one of the pipelines
+                            listed in `jenkins.pipelines`. Default value is
+                            `jenkins.defaultPipeline`
+  -t, --test                The version supplied by `--version` should be
+                            considered from the Test PyPi mirror at
+                            https://test.pypi.org/project/mpyl/.
+  -a, --arguments TEXT      A series of arguments to pass to the pipeline. Note
+                            that will run within the pipenv in jenkins. To
+                            execute `mpyl build status`, pass `-a run -a mpyl -a
+                            build -a status`
+  -bg, --background         Starts Jenkins build in a 'fire and forget' fashion.
+                            Can be set via env var MPYL_JENKINS_BACKGROUND
+  -s, --silent              Indicates whether to show Jenkins' logging or not.
+                            Can be set via env var MPYL_JENKINS_SILENT
+  --tag TEXT
+  -v, --version TEXT        Set a specific test version to be installed. e.g.
+                            '235.*'
+  --all                     Build all projects, regardless of changes on branch
+  --dryrun                  don't push or deploy images
+  --help                    Show this message and exit.


### PR DESCRIPTION
branch: feature/TECH-435-CLI-DRYRUN-VERSION

----
### 📕 [TECH-435](https://vandebron.atlassian.net/browse/TECH-435) CLI improvements <img src="https://secure.gravatar.com/avatar/22987b802af30079346039ff7c67e6fa?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FES-1.png" width="24" height="24" alt="ewaldschrader@vandebron.nl" /> 
Add support for the following things in the CLI

* do a dry run
* set mpyl version of jenkins run (currently we can only set test version)
* deploy parameters 
* other build parameters?

----

We should be able to set the parameters for Jenkins via the cli like:

```
mpyl build jenkins --argument "run run --dryrun"```


→ this probably doesn’t work with `click` . 

- Define custom argument type with click
- Parse string argument

Another (maybe better) option is to just add a dryrun flag for mpyl cli, and then pass that on to jenkins via the jenkins API:

{noformat}mpyl build jenkins --dryrun
```
```

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-274/4/display/redirect) ❗ Failed with exception, started by _Ewald Schrader_  
🚀 _cloudfront-service_, _example-dagster-user-code_, _job_, _kong-sync_, _nodeservice_, _sbtservice_, _sparkJob_  


[TECH-435]: https://vandebron.atlassian.net/browse/TECH-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ