### PR TITLE
feature/TECH 654 pass secrets to docker build

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -216,6 +216,8 @@ jobs:
 
       - name: Build run
         run: mpyl build run
+        env:
+          SOME_CREDENTIAL: credential
 
   Integration_Test_Tag:
     name: Test tag
@@ -281,6 +283,7 @@ jobs:
       - name: Run tag build
         env:
           TAG_NAME: v${{ needs.Build_And_Upload.outputs.mpylVersion }}
+          SOME_CREDENTIAL: credential
         run: mpyl build run
 
   Build_Package:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
                 MPYL_JIRA_TOKEN = credentials('MPYL_JIRA_TOKEN')
                 AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
                 AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+                SOME_CREDENTIAL = 'some-credential'
             }
             steps {
                 script {

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -128,7 +128,7 @@ class KeyValueRef:
 
 
 @dataclass(frozen=True)
-class KeyId:
+class EnvCredential:
     key: str
     secret_id: str
 
@@ -138,7 +138,7 @@ class KeyId:
         secret_id = values.get("id")
         if not key or not secret_id:
             raise KeyError("Credential must have a key and id set.")
-        return KeyId(key, secret_id)
+        return EnvCredential(key, secret_id)
 
 
 @dataclass(frozen=True)
@@ -417,13 +417,15 @@ class Docker:
 @dataclass(frozen=True)
 class BuildArgs:
     plain: list[KeyValueProperty]
-    credentials: list[KeyId]
+    credentials: list[EnvCredential]
 
     @staticmethod
     def from_config(values: dict):
         return BuildArgs(
             plain=list(map(KeyValueProperty.from_config, values.get("plain", []))),
-            credentials=list(map(KeyId.from_config, values.get("credentials", []))),
+            credentials=list(
+                map(EnvCredential.from_config, values.get("credentials", []))
+            ),
         )
 
 

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -130,15 +130,15 @@ class KeyValueRef:
 @dataclass(frozen=True)
 class KeyId:
     key: str
-    id: str
+    secret_id: str
 
     @staticmethod
     def from_config(values: dict):
         key = values.get("key")
-        id = values.get("id")
-        if not key or not id:
-            raise KeyError("Credental must have a key and id set.")
-        return KeyId(key, id)
+        secret_id = values.get("id")
+        if not key or not secret_id:
+            raise KeyError("Credential must have a key and id set.")
+        return KeyId(key, secret_id)
 
 
 @dataclass(frozen=True)

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -128,6 +128,20 @@ class KeyValueRef:
 
 
 @dataclass(frozen=True)
+class KeyId:
+    key: str
+    id: str
+
+    @staticmethod
+    def from_config(values: dict):
+        key = values.get("key")
+        id = values.get("id")
+        if not key or not id:
+            raise KeyError("Credental must have a key and id set.")
+        return KeyId(key, id)
+
+
+@dataclass(frozen=True)
 class StageSpecificProperty(Generic[T]):
     build: Optional[T]
     test: Optional[T]
@@ -403,11 +417,13 @@ class Docker:
 @dataclass(frozen=True)
 class BuildArgs:
     plain: list[KeyValueProperty]
+    credentials: list[KeyId]
 
     @staticmethod
     def from_config(values: dict):
         return BuildArgs(
-            plain=list(map(KeyValueProperty.from_config, values.get("plain", [])))
+            plain=list(map(KeyValueProperty.from_config, values.get("plain", []))),
+            credentials=list(map(KeyId.from_config, values.get("credentials", []))),
         )
 
 

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -17,7 +17,7 @@ to a folder named `$WORKDIR/target/test-reports/`.
 .. include:: ../../../../tests/projects/service/deployment/Dockerfile-mpl
 ```
 """
-
+import os
 from logging import Logger
 
 from .post_docker_build import AfterBuildDocker
@@ -79,6 +79,10 @@ class BuildDocker(Step):
             {
                 arg.key: arg.get_value(step_input.run_properties.target)
                 for arg in step_input.project.build.args.plain
+            }
+            | {
+                arg.key: os.getenv(arg.id)
+                for arg in step_input.project.build.args.credentials
             }
             if step_input.project.build
             else {}

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -80,15 +80,14 @@ class BuildDocker(Step):
                 arg.key: arg.get_value(step_input.run_properties.target)
                 for arg in step_input.project.build.args.plain
             }
-            | dict(
-                filter(
-                    lambda v: v[1] is not None,
-                    {
-                        arg.key: os.getenv(arg.secret_id)
-                        for arg in step_input.project.build.args.credentials
-                    }.items(),
-                )
-            )
+            | {
+                k: v
+                for (k, v) in {
+                    arg.key: os.getenv(arg.secret_id)
+                    for arg in step_input.project.build.args.credentials
+                }.items()
+                if v is not None
+            }
             if step_input.project.build
             else {}
         )

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -80,10 +80,15 @@ class BuildDocker(Step):
                 arg.key: arg.get_value(step_input.run_properties.target)
                 for arg in step_input.project.build.args.plain
             }
-            | {
-                arg.key: os.getenv(arg.id)
-                for arg in step_input.project.build.args.credentials
-            }
+            | dict(
+                filter(
+                    lambda v: v[1] is not None,
+                    {
+                        arg.key: os.getenv(arg.secret_id)
+                        for arg in step_input.project.build.args.credentials
+                    }.items(),
+                )
+            )
             if step_input.project.build
             else {}
         )

--- a/tests/projects/service/deployment/Dockerfile-mpl
+++ b/tests/projects/service/deployment/Dockerfile-mpl
@@ -5,6 +5,8 @@ WORKDIR /tests/projects/service
 RUN yarn install
 
 FROM installer as builder
+ARG SOME_CREDENTIAL
+ARG SOME_ENV
 ENTRYPOINT [ "yarn", "start" ]
 
 FROM installer as tester

--- a/tests/projects/service/deployment/project.yml
+++ b/tests/projects/service/deployment/project.yml
@@ -13,6 +13,9 @@ build:
         test: "Test"
         acceptance: "Acceptance"
         production: "Production"
+    credentials:
+      - key: SOME_CREDENTIAL
+        id: SOME_CREDENTIAL
 dependencies:
   build:
     - 'test/docker/'


### PR DESCRIPTION
Be able to specify credentials to be used in a Dockerfile, which are resolved from env vars

```yaml
build:
  args:
    plain:
      - key: SOME_ENV
        test: "Test"
        acceptance: "Acceptance"
        production: "Production"
    credentials:
      - key: SOME_CREDENTIAL
        id: SOME_CREDENTIAL
```


----
### 📕 [TECH-654](https://vandebron.atlassian.net/browse/TECH-654) Pass secrets to docker build <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
email connector proxy

msp

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-278/4/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-278.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-278.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-278.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-654]: https://vandebron.atlassian.net/browse/TECH-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ