### PR TITLE
[TECH-660] Hardcode the jira so that we're sure it only moves tickets from todo to inprogress

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -6,6 +6,7 @@
 #### Bug Fixes
 
 - Fix the cypress kubectl config merging and passing to docker for linux environments
+- Fix jira ticket state switching to only switch from 'to do' to 'in progress'
 
 
 Details on [Github](https://github.com/Vandebron/mpyl/releases/tag/1.3.2)

--- a/releases/notes/1.3.2.md
+++ b/releases/notes/1.3.2.md
@@ -1,3 +1,4 @@
 #### Bug Fixes
 
 - Fix the cypress kubectl config merging and passing to docker for linux environments
+- Fix jira ticket state switching to only switch from 'to do' to 'in progress'

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -249,10 +249,7 @@ class JiraReporter(Reporter):
                 self._jira.assign_issue(self._ticket, account_id=account_id)
 
     def __move_ticket_forward(self, ticket: JiraTicket):
-        transitions = self._jira.get_issue_transitions(self._ticket)
-        for idx, transition in enumerate(transitions):
-            if transition["name"] == ticket.status_name:
-                if idx == 0:
-                    target_state = transitions[idx + 1]["name"]
-                    self._logger.info(f"Moving {ticket.ticket_id} to {target_state}")
-                    self._jira.issue_transition(self._ticket, target_state)
+        if ticket.status_name == "To Do":
+            target_state = "In Progress"
+            self._logger.info(f"Moving {ticket.ticket_id} to {target_state}")
+            self._jira.issue_transition(self._ticket, target_state)


### PR DESCRIPTION
branch: feature/TECH-660-remove-jira-ticket-transitions

----
### 📕 [TECH-660](https://vandebron.atlassian.net/browse/TECH-660) Do not change jira ticket states <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
There were quite some complaints about mpyl (wrongly) moving Jira tickets to different states, so remove this functionality.

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-279/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-279.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-279.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-279.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-660]: https://vandebron.atlassian.net/browse/TECH-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ