### PR TITLE
feature/TECH 661 fix release process

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -51,13 +51,15 @@ IDE [here](https://black.readthedocs.io/en/stable/integrations/editors.html).
 ## ..create a new release
 
 1. Check out main and pull the latest changes
-2. Run `pipenv run release create`
-3. Choose what release type you want to create. We use [semantic versioning](https://semver.org/). The most important distinction is between regular releases and release candidates.
+2. Choose what release type you want to create. We use [semantic versioning](https://semver.org/). The most important distinction is between regular releases and release candidates.
    1. A *release candidate* does not require release notes and will be published to [test pypi](https://test.pypi.org/project/mpyl/).
    2. A *regular release* requires does require and will be published to [pypi](https://pypi.org/project/mpyl/).
       Create a new release notes file in [releases/notes/](releases/notes/) and name it `<version>.md`
       Noteworthy changes should be added to this file. Think: new cli commands, new features, breaking changes, upgrade
       instructions, etc.
+3. Run `pipenv run release create`
+4. Merge the PR created by this command
+5. Run `pipenv run release publish` on main to publish the release
 
 ## ..troubleshoot Python setup
 

--- a/release.py
+++ b/release.py
@@ -51,7 +51,7 @@ def publish():
         prerelease = "--prerelease" if latest.release_candidate else ""
         output = custom_check_output(
             logging.getLogger(),
-            f"gh release create {latest} --generate-notes {prerelease}",
+            f"gh release create {latest} --generate-notes {prerelease}".strip(),
         )
         if output.success:
             click.echo("Release published")

--- a/releases/notes/1.3.3.md
+++ b/releases/notes/1.3.3.md
@@ -1,0 +1,3 @@
+#### Bug Fixes
+
+- Fix publish release script


### PR DESCRIPTION
- [TECH-661] Fix the publish script by stripping the trailing space
- [TECH-661] Update the dev readme on the release cycle
- [TECH-661] Add release notes for v1.3.3


[TECH-661]: https://vandebron.atlassian.net/browse/TECH-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-661]: https://vandebron.atlassian.net/browse/TECH-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-661]: https://vandebron.atlassian.net/browse/TECH-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-661](https://vandebron.atlassian.net/browse/TECH-661) Update release process <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
* Update the dev-readme to
```
#- ..create a new release

1. Check out main and pull the latest changes
2. Choose what release type you want to create. We use [semantic versioning](https://semver.org/). The most important distinction is between regular releases and release candidates.
   1. A **release candidate** does not require release notes and will be published to [test pypi](https://test.pypi.org/project/mpyl/).
   2. A **regular release** requires does require and will be published to [pypi](https://pypi.org/project/mpyl/).
      Create a new release notes file in [releases/notes/](releases/notes/) and name it `<version>.md`
      Noteworthy changes should be added to this file. Think: new cli commands, new features, breaking changes, upgrade
      instructions, etc.
3. Run `pipenv run release create`
4. Merge the PR created by this command
5. Run `pipenv run release publish` on main to publish the release 
```
* Fix the `pipenv run release publish` script

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-280/3/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-280.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-280.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-280.test.nl/swagger/index.html)*, *sparkJob*  
