### PR TITLE
Move YAML parser back to default settings

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -209,6 +209,7 @@ def __print_status(obj: CliContext):
         repo=obj.repo,
         run_properties=run_properties,
         cli_parameters=MpylCliParameters(local=sys.stdout.isatty()),
+        safe_load_projects=False,
     )
     if result.run_plan:
         console.print(

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -565,7 +565,7 @@ def validate_project(file: TextIO) -> dict:
     :return: the validated schema
     :raises `jsonschema.exceptions.ValidationError` when validation fails
     """
-    yaml_values = YAML(typ="unsafe").load(file)
+    yaml_values = YAML().load(file)
     template = pkgutil.get_data(__name__, "schema/project.schema.yml")
     if not template:
         raise ValueError("Schema project.schema.yml not found in package")
@@ -589,9 +589,7 @@ def load_project(
     with open(root_dir / project_path, encoding="utf-8") as file:
         try:
             start = time.time()
-            yaml_values = (
-                validate_project(file) if strict else YAML(typ="unsafe").load(file)
-            )
+            yaml_values = validate_project(file) if strict else YAML().load(file)
             project = Project.from_config(yaml_values, project_path)
             logging.debug(
                 f"Loaded project {project.path} in {(time.time() - start) * 1000} ms"

--- a/tests/cli/commands/test_build.py
+++ b/tests/cli/commands/test_build.py
@@ -4,13 +4,13 @@ import re
 
 from click.testing import CliRunner
 
-from tests import root_test_path
 from src.mpyl import main_group, add_commands
 from src.mpyl.build import run_build
 from src.mpyl.project import Stage
 from src.mpyl.steps import Step, Meta, ArtifactType, Input, Output
 from src.mpyl.steps.run import RunResult
 from src.mpyl.steps.steps import Steps, StepsCollection
+from tests import root_test_path
 from tests.test_resources.test_data import (
     get_minimal_project,
     RUN_PROPERTIES,

--- a/tests/projects/test_versioning.py
+++ b/tests/projects/test_versioning.py
@@ -6,15 +6,11 @@ from src.mpyl.projects.versioning import (
     upgrade_file,
     get_entry_upgrader_index,
     PROJECT_UPGRADERS,
-    ProjectUpgraderOne8,
-    ProjectUpgraderOne9,
-    ProjectUpgraderOne10,
     load_for_roundtrip,
     pretty_print,
     Upgrader,
     CONFIG_UPGRADERS,
     PROPERTIES_UPGRADERS,
-    ProjectUpgraderOne31,
 )
 from src.mpyl.utilities.yaml import yaml_to_string
 from tests.test_resources.test_data import assert_roundtrip
@@ -39,27 +35,6 @@ class TestVersioning:
         assert get_entry_upgrader_index("1.0.8", PROJECT_UPGRADERS) == 0
         assert get_entry_upgrader_index("1.0.9", PROJECT_UPGRADERS) == 1
         assert get_entry_upgrader_index("1.0.7", PROJECT_UPGRADERS) is None
-
-    def test_first_upgrade(self):
-        self.__roundtrip(
-            self.upgrades_path / "test_project_1_0_8.yml",
-            self.upgrades_path / "test_project_1_0_9.yml",
-            [ProjectUpgraderOne8(), ProjectUpgraderOne9()],
-        )
-
-    def test_namespace_upgrade(self):
-        self.__roundtrip(
-            self.upgrades_path / "test_project_1_0_9.yml",
-            self.upgrades_path / "test_project_1_0_10.yml",
-            [ProjectUpgraderOne9(), ProjectUpgraderOne10()],
-        )
-
-    def test_cmd_replace(self):
-        self.__roundtrip(
-            self.upgrades_path / "test_project_1_0_11.yml",
-            self.upgrades_path / "test_project_1_3_1.yml",
-            [ProjectUpgraderOne10(), ProjectUpgraderOne31()],
-        )
 
     def test_full_upgrade(self):
         self.__roundtrip(

--- a/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
@@ -24,3 +24,13 @@ spec:
       labels:
         alertname: ServiceError
         severity: warning
+    - alert: the name of the alert
+      annotations:
+        description: |-
+          **{{ "{{" }} $value }}** new signup failures with reason `{{ "{{" }} $labels.reason }}`.
+          You can find more details in: <unrelated link>
+      expr: a prometheus expression
+      for: 0m
+      labels:
+        alertname: the name of the alert
+        severity: signup_alerting_once

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -286,6 +286,16 @@ spec:
       labels:
         alertname: ServiceError
         severity: warning
+    - alert: the name of the alert
+      annotations:
+        description: |-
+          **{{ "{{" }} $value }}** new signup failures with reason `{{ "{{" }} $labels.reason }}`.
+          You can find more details in: <unrelated link>
+      expr: a prometheus expression
+      for: 0m
+      labels:
+        alertname: the name of the alert
+        severity: signup_alerting_once
 ---
 # service-monitor
 apiVersion: monitoring.coreos.com/v1

--- a/tests/test_resources/test_data.py
+++ b/tests/test_resources/test_data.py
@@ -53,23 +53,27 @@ def get_config_values() -> dict:
 
 
 def get_project() -> Project:
-    return load_project(resource_path, Path("test_project.yml"), True)
+    return safe_load_project("test_project.yml")
 
 
 def get_minimal_project() -> Project:
-    return load_project(resource_path, Path("test_minimal_project.yml"), True)
+    return safe_load_project("test_minimal_project.yml")
 
 
 def get_job_project() -> Project:
-    return load_project(resource_path, Path("test_job_project.yml"), True)
+    return safe_load_project("test_job_project.yml")
 
 
 def get_cron_job_project() -> Project:
-    return load_project(resource_path, Path("test_cron_job_project.yml"), True)
+    return safe_load_project("test_cron_job_project.yml")
 
 
 def get_spark_project() -> Project:
-    return load_project(resource_path, Path("test_spark_project.yml"), True)
+    return safe_load_project("test_spark_project.yml")
+
+
+def safe_load_project(name: str) -> Project:
+    return load_project(resource_path, Path(name), True, False, True)
 
 
 def get_output() -> Output:

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -80,6 +80,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3

--- a/tests/test_resources/upgrades/test_project_1_0_10.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_10.yml
@@ -82,6 +82,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3

--- a/tests/test_resources/upgrades/test_project_1_0_11.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_11.yml
@@ -82,6 +82,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3

--- a/tests/test_resources/upgrades/test_project_1_0_8.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_8.yml
@@ -80,6 +80,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3

--- a/tests/test_resources/upgrades/test_project_1_0_9.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_9.yml
@@ -81,6 +81,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3

--- a/tests/test_resources/upgrades/test_project_1_3_1.yml
+++ b/tests/test_resources/upgrades/test_project_1_3_1.yml
@@ -80,6 +80,13 @@ deployment:
           forDuration: '1m'
           description: 'Service has encountered errors'
           severity: 'warning'
+        - name: "the name of the alert"
+          expr: "a prometheus expression"
+          forDuration: 0m # Fire instantly
+          severity: signup_alerting_once
+          description: |-
+            **{{ $value }}** new signup failures with reason `{{ $labels.reason }}`.
+            You can find more details in: <unrelated link>
     resources:
       instances:
         all: 3


### PR DESCRIPTION
Fixes #282

I looked back in history for clues as to why this `typ="unsafe"` is needed, and apparently it was done [for performance reasons](https://github.com/Vandebron/mpyl/commit/2b7bee0b9f81841d7b47691b74b12312f9556102#diff-8ab9ddcdb8fee93bb0c9016ade42a4f20cb40bcfa5fd27e03d014c3c5725a542R348).
My suggestion is to disable this setting since it seems to be causing more harm than benefit. 

----
 # ⚠️ Could not find ticket corresponding to `fix/move-yaml-settings-back-to-default. Does your branch name follow the correct pattern?