### PR TITLE
feature/TECH 663 implicit dependencies

### DIFF
--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -175,10 +175,11 @@ class Dependencies(StageSpecificProperty[set[str]]):
 
     @staticmethod
     def from_config(values: dict):
+        build_deps = set(values.get("build", []))
         return Dependencies(
-            build=set(values.get("build", [])),
-            test=set(values.get("test", [])),
-            deploy=set(values.get("deploy", [])),
+            build=build_deps,
+            test=build_deps | set(values.get("test", [])),
+            deploy=build_deps | set(values.get("deploy", [])),
             postdeploy=set(values.get("postdeploy", [])),
         )
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -36,8 +36,8 @@ class TestMpylSchema:
 
         assert project.dependencies is not None
         assert project.dependencies.build == {"test/docker/"}
-        assert project.dependencies.test == {"test/docker/"}
-        assert project.dependencies.deploy == {"test/docker/", "deploy/docker/"}
+        assert project.dependencies.test == {"test/docker/", "test2/docker/"}
+        assert project.dependencies.deploy == {"test/docker/"}
         assert project.dependencies.postdeploy == {"specs/*.js"}
 
         assert project.deployment.kubernetes is not None

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -8,7 +8,7 @@ from src.mpyl.project import load_project, Target
 from tests import root_test_path
 
 
-class TestMplSchema:
+class TestMpylSchema:
     resource_path = root_test_path / "test_resources"
 
     def test_schema_load(self):
@@ -36,7 +36,9 @@ class TestMplSchema:
 
         assert project.dependencies is not None
         assert project.dependencies.build == {"test/docker/"}
-        assert project.dependencies.test == set()
+        assert project.dependencies.test == {"test/docker/"}
+        assert project.dependencies.deploy == {"test/docker/", "deploy/docker/"}
+        assert project.dependencies.postdeploy == {"specs/*.js"}
 
         assert project.deployment.kubernetes is not None
         assert project.deployment.kubernetes.port_mappings == {8080: 80}

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -17,8 +17,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
-  deploy:
-    - 'deploy/docker/'
+  test:
+    - 'test2/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:

--- a/tests/test_resources/test_project.yml
+++ b/tests/test_resources/test_project.yml
@@ -17,6 +17,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
+  deploy:
+    - 'deploy/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:

--- a/tests/test_resources/upgrades/test_project_1_0_8.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_8.yml
@@ -16,6 +16,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
+  deploy:
+    - 'deploy/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:

--- a/tests/test_resources/upgrades/test_project_1_0_8.yml
+++ b/tests/test_resources/upgrades/test_project_1_0_8.yml
@@ -16,8 +16,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
-  deploy:
-    - 'deploy/docker/'
+  test:
+    - 'test2/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:

--- a/tests/test_resources/upgrades/test_project_1_3_1.yml
+++ b/tests/test_resources/upgrades/test_project_1_3_1.yml
@@ -17,8 +17,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
-  deploy:
-    - 'deploy/docker/'
+  test:
+    - 'test2/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:

--- a/tests/test_resources/upgrades/test_project_1_3_1.yml
+++ b/tests/test_resources/upgrades/test_project_1_3_1.yml
@@ -17,6 +17,8 @@ build:
 dependencies:
   build:
     - 'test/docker/'
+  deploy:
+    - 'deploy/docker/'
   postdeploy:
     - 'specs/*.js'
 deployment:


### PR DESCRIPTION
- [TECH-663] Implicitly apply build dependencies to test and deploy
- [TECH-663] Update schema tests to match the new implicit dependency structure


[TECH-663]: https://vandebron.atlassian.net/browse/TECH-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-663]: https://vandebron.atlassian.net/browse/TECH-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-663](https://vandebron.atlassian.net/browse/TECH-663) Change dependency strategy <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
from [2023-10-18+CI+CD+Guild](https://vandebron.atlassian.net/wiki/spaces/DIG/pages/95581544906767/2023-10-18+CI+CD+Guild) 

In MPL a build dependency implied test and deploy

MPyL

* project yaml contains list of dependencies per stage

MPL

* dependencies for test implies dependencies for build + test

=> build dependency should imply test and deploy

=> test but not build should only test

🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-289/5/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-289.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-289.test.nl/swagger/index.html)*, *[sbtservice](https://sbtservice-289.test.nl/swagger/index.html)*, *sparkJob*  
