### PR TITLE
fix/FTS 691 Improvements

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -56,6 +56,9 @@ directory.
 Using this functionality, you can define different deployments for the same project.
 For example, you can deploy the same project with different settings to different environments.
 
+#### Bugfixes
+
+- Fix TLS creation in ingress routes
 
 Details on [Github](https://github.com/Vandebron/mpyl/releases/tag/1.4.0)
 

--- a/releases/notes/1.4.0.md
+++ b/releases/notes/1.4.0.md
@@ -50,3 +50,7 @@ The MPyL recognizes the `project-override-*.yml` files and merges them to the pa
 directory.
 Using this functionality, you can define different deployments for the same project.
 For example, you can deploy the same project with different settings to different environments.
+
+#### Bugfixes
+
+- Fix TLS creation in ingress routes

--- a/releases/notes/1.4.1.md
+++ b/releases/notes/1.4.1.md
@@ -1,0 +1,6 @@
+#### Bugfixes
+
+- fix project overlays (merging children projects with their parent)
+- Github Check output only shows test summary, not the full test output
+- Get target branch in cache repo from the run properties
+- Only transition non-Epic Jira tickets to 'To Do'

--- a/releases/notes/1.4.1.md
+++ b/releases/notes/1.4.1.md
@@ -1,6 +1,6 @@
 #### Bugfixes
 
-- fix project overlays (merging children projects with their parent)
+- Fix project overlays (merging children projects with their parent)
 - Github Check output only shows test summary, not the full test output
 - Get target branch in cache repo from the run properties
 - Only transition non-Epic Jira tickets to 'To Do'

--- a/src/mpyl/reporting/formatting/text.py
+++ b/src/mpyl/reporting/formatting/text.py
@@ -31,6 +31,7 @@ def to_test_report(artifact: JunitTestSpec) -> str:
     test_result.append(f"{total_tests} \n\n")
     for suite in suites:
         test_result.append(
-            f"Suite {suite.name}: ${suite.tests} tests, ${suite.failures} failures, ${suite.skipped} skipped\n"
+            f"Suite {suite.name}: tests={suite.tests}, failures={suite.failures}, "
+            f"errors={suite.errors}, skipped={suite.skipped}\n"
         )
     return "".join(test_result)

--- a/src/mpyl/reporting/formatting/text.py
+++ b/src/mpyl/reporting/formatting/text.py
@@ -24,16 +24,13 @@ def to_string(run_result: RunResult) -> str:
 
 
 def to_test_report(artifact: JunitTestSpec) -> str:
-    """Gather the first test suites and test cases. Output is truncated to around 200 lines to not overwhelm Github"""
+    """Gather the test suites and their results."""
     test_result = []
     suites = to_test_suites(artifact)
     total_tests = sum_suites(suites)
     test_result.append(f"{total_tests} \n\n")
     for suite in suites:
-        test_result.append(f"Suite {suite.name}\n")
-        if len(test_result) > 200:
-            test_result.append("  ... output truncated\n")
-            break
-        for case in suite:
-            test_result.append(f"  Case {case.name} \n")
+        test_result.append(
+            f"Suite {suite.name}: ${suite.tests} tests, ${suite.failures} failures, ${suite.skipped} skipped\n"
+        )
     return "".join(test_result)

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -253,7 +253,7 @@ class JiraReporter(Reporter):
                 self._jira.assign_issue(self._ticket, account_id=account_id)
 
     def __move_ticket_forward(self, ticket: JiraTicket):
-        if ticket.status_name == "To Do" and ticket.issue_type == "Epic":
+        if ticket.status_name == "To Do" and ticket.issue_type != "Epic":
             target_state = "In Progress"
             self._logger.info(f"Moving {ticket.ticket_id} to {target_state}")
             self._jira.issue_transition(self._ticket, target_state)

--- a/src/mpyl/reporting/targets/jira.py
+++ b/src/mpyl/reporting/targets/jira.py
@@ -253,7 +253,7 @@ class JiraReporter(Reporter):
                 self._jira.assign_issue(self._ticket, account_id=account_id)
 
     def __move_ticket_forward(self, ticket: JiraTicket):
-        if ticket.status_name == "To Do":
+        if ticket.status_name == "To Do" and ticket.issue_type == "Epic":
             target_state = "In Progress"
             self._logger.info(f"Moving {ticket.ticket_id} to {target_state}")
             self._jira.issue_transition(self._ticket, target_state)

--- a/tests/reporting/formatting/test_resources/simple_run.txt
+++ b/tests/reporting/formatting/test_resources/simple_run.txt
@@ -5,59 +5,8 @@ Stage test
 2019-01-04 16:41:45+02:00 - test - Stage(name='test', icon='📋') - success: True 
 TestRunSummary(tests=51, failures=1, errors=0, skipped=0) 
 
-Suite pytest
-  Case test_schema_load 
-  Case test_schema_load_validation 
-  Case test_target_by_value 
-  Case test_should_print_results_as_string 
-  Case test_should_find_invalidated_test_dependencies 
-  Case test_should_find_invalidated_dependencies 
-  Case test_output_no_artifact_roundtrip 
-  Case test_output_roundtrip 
-  Case test_should_return_error_if_stage_not_defined 
-  Case test_probe_values_should_be_customizable 
-  Case test_probe_deserialization_failure_should_throw 
-  Case test_load_config 
-  Case test_should_validate_against_crd_schema 
-  Case test_chart_roundtrip[deployment] 
-  Case test_chart_roundtrip[service] 
-  Case test_chart_roundtrip[serviceaccount] 
-  Case test_chart_roundtrip[sealedsecrets] 
-  Case test_chart_roundtrip[ingress-https-route] 
-Suite nl.vandebron.api.invoices.services.InvoiceOrchestratorSpecs
-  Case Invoice orchestrator should Return the stream of incoming data when downloading a PDF file 
-  Case Invoice orchestrator should Filter invoices by type 
-  Case Invoice orchestrator should Enrich ecedo producer invoices with BusinessCentral vendor invoices 
-  Case Invoice orchestrator should Enrich ecedo invoice with BusinessCentral data for roles EV and CONSUMER 
-  Case Invoice orchestrator should getInvoicesSummary should Generate invoices summary from ecedo data with multiple rows 
-  Case Invoice orchestrator should getInvoicesSummary should Generate invoices summary from ecedo data with a single row 
-  Case Invoice orchestrator should getInvoicesSummary should Return a 404 error if ecedo returns an empty list for InvoiceRowsTotals 
-  Case Invoice orchestrator should getInvoicesSummary should Return a 404 error if total usage is zero 
-  Case Invoice orchestrator should toMWH should convert KWh to MWh 
-  Case Invoice orchestrator should toMWH should convert Wh to MWh 
-  Case Invoice orchestrator should toMWH should do not change value for MWh 
-  Case Invoice orchestrator should toMWH should return a left for unknown unit 
-  Case Invoice orchestrator should toInvoiceDto should set paymentProcessing as true when both maybeOpen and PPEntryPresent are true 
-  Case Invoice orchestrator should zipMaps should merge two maps 
-  Case Invoice orchestrator should embedSubInvoicesInParent should return None for empty arrays 
-  Case Invoice orchestrator should embedSubInvoicesInParent should return only parent for one invoice 
-  Case Invoice orchestrator should embedSubInvoicesInParent should separate parent and sort children 
-  Case Invoice orchestrator should createPaymentPlan should accept requests with valid payload 
-  Case Invoice orchestrator should createPaymentPlan should reject requests with invalid numberOfMonths 
-  Case Invoice orchestrator should getPaymentPlanStartDate should set start date as 18th of the coming month 
-  Case Invoice orchestrator should getInvoiceDataSet should return a result when it exists in Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when invoice has different company label id Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when invoice doesn't exist in Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when organization doesn't exist in Ecedo 
-Suite nl.vandebron.api.invoices.routes.InvoiceRouteSpecs
-  Case Invoice routes should serve all invoices if user user owns organization 
-  Case Invoice routes should create payment plan 
-  Case Invoice routes should serve invoices summary 
-  Case Invoice routes should filter on queried type and honour contract 
-  Case Invoice routes should serve invoices for specified invoice types 
-  Case Invoice routes should refuse to serve invoices if user reference in path does not match token 
-  Case Invoice routes should refuse request without filter 
-  Case Invoice routes should use proper headers when returning a PDF invoice 
-  Case Invoice routes should GET '/api/v1/organizations/{customerReference}/invoices/{invoiceId}' should return a 200 with invoice details 
+Suite pytest: tests=18, failures=0, errors=0, skipped=0
+Suite nl.vandebron.api.invoices.services.InvoiceOrchestratorSpecs: tests=24, failures=0, errors=0, skipped=0
+Suite nl.vandebron.api.invoices.routes.InvoiceRouteSpecs: tests=9, failures=1, errors=0, skipped=0
 Stage deploy
 2019-01-04 16:41:45+02:00 - test - Stage(name='deploy', icon='🚀') - success: True 

--- a/tests/reporting/formatting/test_resources/simple_test.txt
+++ b/tests/reporting/formatting/test_resources/simple_test.txt
@@ -1,56 +1,5 @@
 TestRunSummary(tests=51, failures=1, errors=0, skipped=0) 
 
-Suite pytest
-  Case test_schema_load 
-  Case test_schema_load_validation 
-  Case test_target_by_value 
-  Case test_should_print_results_as_string 
-  Case test_should_find_invalidated_test_dependencies 
-  Case test_should_find_invalidated_dependencies 
-  Case test_output_no_artifact_roundtrip 
-  Case test_output_roundtrip 
-  Case test_should_return_error_if_stage_not_defined 
-  Case test_probe_values_should_be_customizable 
-  Case test_probe_deserialization_failure_should_throw 
-  Case test_load_config 
-  Case test_should_validate_against_crd_schema 
-  Case test_chart_roundtrip[deployment] 
-  Case test_chart_roundtrip[service] 
-  Case test_chart_roundtrip[serviceaccount] 
-  Case test_chart_roundtrip[sealedsecrets] 
-  Case test_chart_roundtrip[ingress-https-route] 
-Suite nl.vandebron.api.invoices.services.InvoiceOrchestratorSpecs
-  Case Invoice orchestrator should Return the stream of incoming data when downloading a PDF file 
-  Case Invoice orchestrator should Filter invoices by type 
-  Case Invoice orchestrator should Enrich ecedo producer invoices with BusinessCentral vendor invoices 
-  Case Invoice orchestrator should Enrich ecedo invoice with BusinessCentral data for roles EV and CONSUMER 
-  Case Invoice orchestrator should getInvoicesSummary should Generate invoices summary from ecedo data with multiple rows 
-  Case Invoice orchestrator should getInvoicesSummary should Generate invoices summary from ecedo data with a single row 
-  Case Invoice orchestrator should getInvoicesSummary should Return a 404 error if ecedo returns an empty list for InvoiceRowsTotals 
-  Case Invoice orchestrator should getInvoicesSummary should Return a 404 error if total usage is zero 
-  Case Invoice orchestrator should toMWH should convert KWh to MWh 
-  Case Invoice orchestrator should toMWH should convert Wh to MWh 
-  Case Invoice orchestrator should toMWH should do not change value for MWh 
-  Case Invoice orchestrator should toMWH should return a left for unknown unit 
-  Case Invoice orchestrator should toInvoiceDto should set paymentProcessing as true when both maybeOpen and PPEntryPresent are true 
-  Case Invoice orchestrator should zipMaps should merge two maps 
-  Case Invoice orchestrator should embedSubInvoicesInParent should return None for empty arrays 
-  Case Invoice orchestrator should embedSubInvoicesInParent should return only parent for one invoice 
-  Case Invoice orchestrator should embedSubInvoicesInParent should separate parent and sort children 
-  Case Invoice orchestrator should createPaymentPlan should accept requests with valid payload 
-  Case Invoice orchestrator should createPaymentPlan should reject requests with invalid numberOfMonths 
-  Case Invoice orchestrator should getPaymentPlanStartDate should set start date as 18th of the coming month 
-  Case Invoice orchestrator should getInvoiceDataSet should return a result when it exists in Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when invoice has different company label id Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when invoice doesn't exist in Ecedo 
-  Case Invoice orchestrator should getInvoiceDataSet should return a 404 when organization doesn't exist in Ecedo 
-Suite nl.vandebron.api.invoices.routes.InvoiceRouteSpecs
-  Case Invoice routes should serve all invoices if user user owns organization 
-  Case Invoice routes should create payment plan 
-  Case Invoice routes should serve invoices summary 
-  Case Invoice routes should filter on queried type and honour contract 
-  Case Invoice routes should serve invoices for specified invoice types 
-  Case Invoice routes should refuse to serve invoices if user reference in path does not match token 
-  Case Invoice routes should refuse request without filter 
-  Case Invoice routes should use proper headers when returning a PDF invoice 
-  Case Invoice routes should GET '/api/v1/organizations/{customerReference}/invoices/{invoiceId}' should return a 200 with invoice details 
+Suite pytest: tests=18, failures=0, errors=0, skipped=0
+Suite nl.vandebron.api.invoices.services.InvoiceOrchestratorSpecs: tests=24, failures=0, errors=0, skipped=0
+Suite nl.vandebron.api.invoices.routes.InvoiceRouteSpecs: tests=9, failures=1, errors=0, skipped=0

--- a/tests/reporting/test_simple_reporting.py
+++ b/tests/reporting/test_simple_reporting.py
@@ -11,11 +11,13 @@ class TestReporting:
     def test_should_print_results_as_string(self):
         run_result = create_test_result()
         simple_report = to_string(run_result)
-        assert_roundtrip(self.test_resource_path / "simple_run.txt", simple_report)
+        assert_roundtrip(
+            self.test_resource_path / "simple_run.txt", simple_report, overwrite=True
+        )
 
     def test_should_convert_test_report_to_string(self):
         spec = JunitTestSpec(str(self.test_resource_path))
         test_report = to_test_report(spec)
         assert_roundtrip(
-            self.test_resource_path / "simple_test.txt", test_report, overwrite=False
+            self.test_resource_path / "simple_test.txt", test_report, overwrite=True
         )

--- a/tests/reporting/test_simple_reporting.py
+++ b/tests/reporting/test_simple_reporting.py
@@ -12,12 +12,12 @@ class TestReporting:
         run_result = create_test_result()
         simple_report = to_string(run_result)
         assert_roundtrip(
-            self.test_resource_path / "simple_run.txt", simple_report, overwrite=True
+            self.test_resource_path / "simple_run.txt", simple_report, overwrite=False
         )
 
     def test_should_convert_test_report_to_string(self):
         spec = JunitTestSpec(str(self.test_resource_path))
         test_report = to_test_report(spec)
         assert_roundtrip(
-            self.test_resource_path / "simple_test.txt", test_report, overwrite=True
+            self.test_resource_path / "simple_test.txt", test_report, overwrite=False
         )


### PR DESCRIPTION
1. 

When a lot of tests are being run, the github check of the pipeline cannot be updated because:
```
Unexpected exception: 422 {"message": "Invalid request.\n\nOnly 65535 characters are allowed; 133237 were supplied.", "documentation_url":                   
          "https://docs.github.com/rest/checks/runs#update-a-check-run"}  
```

Do not update the check with all the individual test cases, but only push a summary

2. 

Fix target branch for tag builds in artifacts repo 

3. 

Filter epics from to do transitions

----
### 📕 [FTS-691](https://vandebron.atlassian.net/browse/FTS-691) Add lostSdePerMwhInEuros curtailment attribute logic <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:0743fec0-0b1e-4b31-bef8-1ac1f4f7bd29/1f0a5425-b55d-4e6a-850a-1eacd6c26c9f/24" width="24" height="24" alt="rosario@vandebron.nl" /> 


`lostSdePerMwhInEuros` is used in the curtailment decision logic. It is determiend as follows (with a **floor of 0**):

```python
if estimatedSdeCorrectionPriceInEuros < baseElectricityPriceInEuros:
  lostSdePerMwhInEuros = tenderPriceInEuros - baseElectricityPriceInEuros

else:
  lostSdePerMwhInEuros = tenderPriceInEuros - estimatedSdeCorrectionPriceInEuros
```

* Calculate the value
**** If calculation of `lostSdePerMwhInEuros` < 0 → put it to 0.
* Add it to the enriched stream 
**** New field
**** Nonnegative float

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-292/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-292.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-292.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-292.test.nl/swagger/index.html)*, *sparkJob*  


[FTS-691]: https://vandebron.atlassian.net/browse/FTS-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ