### PR TITLE
[TECH-599] Use docker config instead of dockerRegistryConfig

### DIFF
--- a/src/mpyl/steps/deploy/dagster.py
+++ b/src/mpyl/steps/deploy/dagster.py
@@ -24,7 +24,7 @@ from .k8s.resources.dagster import to_user_code_values, to_grpc_server_entry, Co
 from .. import Step, Meta, ArtifactType, Input, Output
 from ...project import Target
 from ...utilities.dagster import DagsterConfig
-from ...utilities.docker import DockerRegistryConfig
+from ...utilities.docker import DockerConfig
 from ...utilities.helm import convert_to_helm_release_name, shorten_name
 
 
@@ -104,7 +104,7 @@ class DeployDagster(Step):
             project=step_input.project,
             name_suffix=name_suffix,
             run_properties=properties,
-            docker_config=DockerRegistryConfig.from_dict(properties.config),
+            docker_config=DockerConfig.from_dict(properties.config),
         )
 
         self._logger.debug(f"Deploying user code with values: {user_code_deployment}")

--- a/src/mpyl/steps/deploy/k8s/__init__.py
+++ b/src/mpyl/steps/deploy/k8s/__init__.py
@@ -10,6 +10,7 @@ from typing import Optional
 from kubernetes import config, client
 from kubernetes.client import V1ConfigMap, ApiException, V1Deployment
 from ruamel.yaml import yaml_object, YAML
+import yaml as dict_to_yaml_str
 
 from .helm import write_helm_chart, GENERATED_WARNING
 from ...deploy.k8s.resources import CustomResourceDefinition
@@ -183,7 +184,7 @@ def get_version_of_deployment(
 def update_config_map_field(
     config_map: V1ConfigMap, field: str, data: dict
 ) -> V1ConfigMap:
-    config_map.data[field] = yaml.dump(data)
+    config_map.data[field] = dict_to_yaml_str.dump(data)
     return config_map
 
 


### PR DESCRIPTION
branch: bug/TECH-599-fix-dockerconfig-creation

----
### 📕 [TECH-599](https://vandebron.atlassian.net/browse/TECH-599) Migrate all dagster/scripting projects to be deployed with MPyL <img src="https://secure.gravatar.com/avatar/c3ee2ab42ab6a6ebc8c3a492a7b9cbf6?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FKG-5.png" width="24" height="24" alt="katringrunert@vandebron.nl" /> 
[2926](https://github.com/Vandebron/scripting/pull/2926)  needs to be merged first (linting and updating of runner and config)

----

to test the behaviour of two user-code repositories co-existing (MPL and MPyL dpeloyed) I would like to:

test out a usercode deployment on Acceptance:

* make backup of the workspace.yml file (copy YAML and store locally)
* deploy a tag with MPL (suf or so)
* then deploy the same tag with MPyL
* check if everything’s still working

the results of this test will decide whether a hard-switch for ALL projects is needed or what steps can be done to make a softer switch happen/.

----

check in with Tim (platform) about the workspace-configmap backup

----

check on how to deprecate a Jenkinspipeline?

----

* fix linting errors (check mpyl lint --all)
**** deprecate the kubernets.secrets tab once everything is fully running on MPyL

----

* schedule knowledge share for all affected teams

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-293/2/display/redirect) ✅ Successful, started by _Katrin Grunert_  
🚀 *[cloudfront-service](https://cloudfront-service-293.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-293.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-293.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-599]: https://vandebron.atlassian.net/browse/TECH-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ