### PR TITLE
[TECH-599] Prepare release notes

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -50,16 +50,18 @@ IDE [here](https://black.readthedocs.io/en/stable/integrations/editors.html).
 
 ## ..create a new release
 
-1. Check out main and pull the latest changes
-2. Choose what release type you want to create. We use [semantic versioning](https://semver.org/). The most important distinction is between regular releases and release candidates.
+1. Create a new release notes file in [releases/notes/](releases/notes/) and name it `<version>.md`
+   Noteworthy changes should be added to this file. Think: new cli commands, new features, breaking changes, upgrade
+   instructions, etc. 
+   Ideally create this file already when starting to work on a new version. 
+   Each PR that is to be included in that release, can add their notes to this file.
+2. Check out main and pull the latest changes
+3. Choose what release type you want to create. We use [semantic versioning](https://semver.org/). The most important distinction is between regular releases and release candidates.
    1. A *release candidate* does not require release notes and will be published to [test pypi](https://test.pypi.org/project/mpyl/).
    2. A *regular release* requires does require and will be published to [pypi](https://pypi.org/project/mpyl/).
-      Create a new release notes file in [releases/notes/](releases/notes/) and name it `<version>.md`
-      Noteworthy changes should be added to this file. Think: new cli commands, new features, breaking changes, upgrade
-      instructions, etc.
-3. Run `pipenv run release create`
-4. Merge the PR created by this command
-5. Run `pipenv run release publish` on main to publish the release
+4. Run `pipenv run release create`
+5. Merge the PR created by this command
+6. Run `pipenv run release publish` on main to publish the release
 
 ## ..troubleshoot Python setup
 

--- a/releases/notes/1.4.2.md
+++ b/releases/notes/1.4.2.md
@@ -1,0 +1,4 @@
+#### Bugfixes
+
+- Fix on how the selected DockerRegistry is being opened when writing the values of a dagster user code helm chart
+- Fix ruamel.yaml.YAML() name overshadowing with the yaml package in the k8s module


### PR DESCRIPTION
branch: feature/TECH-599-prepare-release-notes-for-1.4.2

----
### 📕 [TECH-599](https://vandebron.atlassian.net/browse/TECH-599) Migrate all dagster/scripting projects to be deployed with MPyL <img src="https://secure.gravatar.com/avatar/c3ee2ab42ab6a6ebc8c3a492a7b9cbf6?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FKG-5.png" width="24" height="24" alt="katringrunert@vandebron.nl" /> 
[2926](https://github.com/Vandebron/scripting/pull/2926)  needs to be merged first (linting and updating of runner and config)

----

to test the behaviour of two user-code repositories co-existing (MPL and MPyL dpeloyed) I would like to:

test out a usercode deployment on Acceptance:

* make backup of the workspace.yml file (copy YAML and store locally)
* deploy a tag with MPL (suf or so)
* then deploy the same tag with MPyL
* check if everything’s still working

the results of this test will decide whether a hard-switch for ALL projects is needed or what steps can be done to make a softer switch happen/.

----

check in with Tim (platform) about the workspace-configmap backup

----

check on how to deprecate a Jenkinspipeline?

----

* fix linting errors (check mpyl lint --all)
**** deprecate the kubernets.secrets tab once everything is fully running on MPyL

----

* schedule knowledge share for all affected teams

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-297/2/display/redirect) ✅ Successful, started by _Katrin Grunert_  
🚀 *[cloudfront-service](https://cloudfront-service-297.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-297.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-297.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-599]: https://vandebron.atlassian.net/browse/TECH-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ