### PR TITLE
feature/TECH 694 Improve traefik config

### DIFF
--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -346,7 +346,7 @@ class TraefikHost:
     tls: Optional[TargetProperty[str]]
     whitelists: TargetProperty[list[str]]
     priority: Optional[int]
-    insecure: bool = False
+    insecure: bool
 
     @staticmethod
     def from_config(values: dict):

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -345,6 +345,8 @@ class TraefikHost:
     service_port: Optional[int]
     tls: Optional[TargetProperty[str]]
     whitelists: TargetProperty[list[str]]
+    priority: Optional[int]
+    insecure: bool = False
 
     @staticmethod
     def from_config(values: dict):
@@ -353,6 +355,8 @@ class TraefikHost:
             service_port=values.get("servicePort"),
             tls=TargetProperty.from_config(values.get("tls", {})),
             whitelists=TargetProperty.from_config(values.get("whitelists", {})),
+            priority=values.get("priority"),
+            insecure=values.get("insecure", False),
         )
 
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -241,11 +241,10 @@ class ChartBuilder:
             "app.kubernetes.io/instance": self.release_name,
         }
 
-        if len(self.project.maintainer) > 1:
+        if len(self.project.maintainer) > 0:
             app_labels["maintainers"] = ".".join(self.project.maintainer).replace(
                 " ", "_"
             )
-        elif len(self.project.maintainer) > 0:
             app_labels["maintainer"] = self.project.maintainer[0].replace(" ", "_")
 
         app_labels["version"] = run_properties.versioning.identifier

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -481,6 +481,7 @@ class ChartBuilder:
                 else self.__find_default_port(),
                 white_lists=to_white_list(host.whitelists),
                 tls=host.tls.get_value(self.target) if host.tls else None,
+                insecure=host.insecure,
             )
             for idx, host in enumerate(hosts if hosts else default_hosts)
         ]

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -716,7 +716,7 @@ class ChartBuilder:
         liveness_probe, startup_probe = self._construct_probes()
 
         container = V1Container(
-            name=self.release_name,
+            name="service",
             image=self._get_image(),
             env=self._get_env_vars(),
             ports=ports,

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -498,6 +498,18 @@ class ChartBuilder:
                 pr_number=self.step_input.run_properties.versioning.pr_number,
             )
             for i, host in enumerate(hosts)
+        ] + [
+            V1AlphaIngressRoute(
+                metadata=self._to_object_meta(
+                    name=f"{self.release_name}-ingress-{i}-http"
+                ),
+                host=host,
+                target=self.target,
+                namespace=get_namespace(self.step_input.run_properties, self.project),
+                pr_number=self.step_input.run_properties.versioning.pr_number,
+                https=False,
+            )
+            for i, host in enumerate(hosts)
         ]
 
     def to_middlewares(self) -> dict[str, V1AlphaMiddleware]:
@@ -803,11 +815,15 @@ def _to_service_components_chart(builder):
         if metrics and metrics.enabled
         else {}
     )
-    ingress = {
+    ingress_https = {
         f"ingress-https-route-{i}": route
         for i, route in enumerate(builder.to_ingress_routes())
     }
-    return common_chart | prometheus_chart | ingress
+    ingress_http = {
+        f"ingress-https-route-{i}": route
+        for i, route in enumerate(builder.to_ingress_routes())
+    }
+    return common_chart | prometheus_chart | ingress_https
 
 
 def to_job_chart(builder: ChartBuilder) -> dict[str, CustomResourceDefinition]:

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -52,7 +52,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
                 {"name": host.name, "kind": "Service", "port": host.service_port}
             ],
             "middlewares": [
-                {"name": "traefik-https-redirect@kubernetescrd"},
+                {"name": "traefik-https-redirect@kubernetescrd"} if not https else None,
                 {"name": host.full_name},
             ],
         }

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -2,7 +2,7 @@
 This module contains the traefik ingress route CRD.
 """
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from kubernetes.client import V1ObjectMeta
 
@@ -58,9 +58,11 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
         }
 
         if host.traefik_host.priority:
-            route |= {"priority": host.traefik_host.priority}
+            route |= {"priority": str(host.traefik_host.priority)}
 
-        tls = {"secretName": host.tls if host.tls else "le-prod-wildcard-cert"}
+        tls: dict[str, Union[str, dict]] = {
+            "secretName": host.tls if host.tls else "le-prod-wildcard-cert"
+        }
         if host.insecure:
             tls |= {"options": {"name": "insecure-ciphers", "namespace": "traefik"}}
 

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -51,7 +51,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
                 {"name": host.name, "kind": "Service", "port": host.service_port}
             ],
             "middlewares": [
-                {"name": "traefik-https-redirect@kubernetescrd"} if not https else None,
+                {"name": "traefik-https-redirect@kubernetescrd"},
                 {"name": host.full_name},
             ],
         }

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -2,7 +2,7 @@
 This module contains the traefik ingress route CRD.
 """
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 from kubernetes.client import V1ObjectMeta
 
@@ -42,7 +42,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
                 return host.replace("{PR-NUMBER}", str(pr_number))
             return host
 
-        route = {
+        route: dict[str, Any] = {
             "kind": "Rule",
             "match": _interpolate_names(
                 host=host.traefik_host.host.get_value(target),
@@ -58,7 +58,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
         }
 
         if host.traefik_host.priority:
-            route |= {"priority": str(host.traefik_host.priority)}
+            route |= {"priority": host.traefik_host.priority}
 
         tls: dict[str, Union[str, dict]] = {
             "secretName": host.tls if host.tls else "le-prod-wildcard-cert"

--- a/src/mpyl/steps/deploy/kubernetes.py
+++ b/src/mpyl/steps/deploy/kubernetes.py
@@ -38,9 +38,9 @@ class DeployKubernetes(Step):
 
     @staticmethod
     def try_extract_hostname(
-        chart: dict[str, CustomResourceDefinition]
+        chart: dict[str, CustomResourceDefinition], service_name: str
     ) -> Optional[str]:
-        ingress = chart.get("ingress-https-route-0")
+        ingress = chart.get(f"{service_name}-ingress-0-https")
         if ingress:
             routes = ingress.spec.get("routes", {})
             if routes:
@@ -63,7 +63,7 @@ class DeployKubernetes(Step):
             self._logger, chart, step_input, properties.target, builder.release_name
         )
         if deploy_result.success:
-            hostname = self.try_extract_hostname(chart)
+            hostname = self.try_extract_hostname(chart, builder.project.name)
             url = None
             if hostname:
                 has_specific_routes_configured: bool = bool(

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/cronjob.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/cronjob.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: job
     app.kubernetes.io/instance: job
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -27,6 +28,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: job
             app.kubernetes.io/instance: job
+            maintainers: MPyL
             maintainer: MPyL
             version: pr-1234
             revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: minimalservice
     app.kubernetes.io/instance: minimalservice
+    maintainers: MPyL
     maintainer: MPyL
     version: 20230829-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -21,7 +21,6 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: minimalservice-ingress-0-whitelist
   entryPoints:
   - websecure

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -20,8 +20,8 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: minimalservice-ingress-0-whitelist
     - name: traefik-https-redirect@kubernetescrd
+    - name: minimalservice-ingress-0-whitelist
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: minimalservice
     app.kubernetes.io/instance: minimalservice
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -1,0 +1,28 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: minimalservice
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minimalservice
+    app.kubernetes.io/instance: minimalservice
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: minimalservice-ingress-0-https
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`minimalservice-1234.test-backend.nl`)
+    services:
+    - name: minimalservice
+      kind: Service
+      port: 8080
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: minimalservice-ingress-0-whitelist
+  entryPoints:
+  - websecure
+  tls:
+    secretName: le-custom-prod-wildcard-cert

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -21,7 +21,6 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: minimalservice-ingress-0-whitelist
   entryPoints:
   - websecure

--- a/tests/steps/deploy/k8s/chart/templates/job/job.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/job.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: job
     app.kubernetes.io/instance: job
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -23,6 +24,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: job
         app.kubernetes.io/instance: job
+        maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
         revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: job
     app.kubernetes.io/instance: job
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           periodSeconds: 30
           successThreshold: 0
           timeoutSeconds: 20
-        name: dockertest
+        name: service
         ports:
         - containerPort: 80
           name: port-0

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -33,6 +34,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dockertest
         app.kubernetes.io/instance: dockertest
+        maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
         revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
@@ -2,27 +2,25 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
-    name: minimalservice
+    name: dockertest
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: minimalservice
-    app.kubernetes.io/instance: minimalservice
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: minimalservice-ingress-0-https
+  name: dockertest-ingress-0-http
 spec:
   routes:
   - kind: Rule
-    match: Host(`minimalservice-1234.test-backend.nl`)
+    match: Host(`payments-1234.test.nl`)
     services:
-    - name: minimalservice
+    - name: dockertest
       kind: Service
       port: 8080
     middlewares:
-    - name: minimalservice-ingress-0-whitelist
     - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-0-whitelist
   entryPoints:
-  - websecure
-  tls:
-    secretName: le-custom-prod-wildcard-cert
+  - web

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -20,8 +20,8 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: dockertest-ingress-0-whitelist
     - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-0-whitelist
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -21,7 +21,6 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-0-whitelist
   entryPoints:
   - websecure

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -26,3 +26,6 @@ spec:
   - websecure
   tls:
     secretName: le-custom-prod-wildcard-cert
+    options:
+      name: insecure-ciphers
+      namespace: traefik

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -1,0 +1,26 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-ingress-1-http
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`some.other.host.com`)
+    services:
+    - name: dockertest
+      kind: Service
+      port: 4091
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-1-whitelist
+  entryPoints:
+  - web

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -22,5 +22,6 @@ spec:
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
+    priority: 1000
   entryPoints:
   - web

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -22,6 +22,7 @@ spec:
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
+    priority: 1000
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -20,8 +20,8 @@ spec:
       kind: Service
       port: 4091
     middlewares:
-    - name: dockertest-ingress-1-whitelist
     - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-1-whitelist
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -21,7 +21,6 @@ spec:
       kind: Service
       port: 4091
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
     priority: 1000
   entryPoints:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/role.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/rolebinding.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/rolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/service/service.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/spark/config-map.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/config-map.yaml
@@ -38,6 +38,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sparkjob
     app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/spark/role.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/role.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sparkjob
     app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/spark/rolebinding.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/rolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sparkjob
     app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/chart/templates/spark/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/service-account.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sparkjob
     app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -109,6 +109,64 @@ spec:
       serviceAccount: dockertest
       serviceAccountName: dockertest
 ---
+# dockertest-ingress-0-http
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-ingress-0-http
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`payments-1234.test.nl`)
+    services:
+    - name: dockertest
+      kind: Service
+      port: 8080
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-0-whitelist
+  entryPoints:
+  - web
+---
+# dockertest-ingress-0-https
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-ingress-0-https
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`payments-1234.test.nl`)
+    services:
+    - name: dockertest
+      kind: Service
+      port: 8080
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-0-whitelist
+  entryPoints:
+  - websecure
+  tls:
+    secretName: le-custom-prod-wildcard-cert
+---
 # dockertest-ingress-0-whitelist
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
@@ -135,6 +193,64 @@ spec:
     - 1.2.3.1
     - 1.2.3.4
 ---
+# dockertest-ingress-1-http
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-ingress-1-http
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`some.other.host.com`)
+    services:
+    - name: dockertest
+      kind: Service
+      port: 4091
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-1-whitelist
+  entryPoints:
+  - web
+---
+# dockertest-ingress-1-https
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  labels:
+    name: dockertest
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: dockertest-ingress-1-https
+spec:
+  routes:
+  - kind: Rule
+    match: Host(`some.other.host.com`)
+    services:
+    - name: dockertest
+      kind: Service
+      port: 4091
+    middlewares:
+    - name: traefik-https-redirect@kubernetescrd
+    - name: dockertest-ingress-1-whitelist
+  entryPoints:
+  - websecure
+  tls:
+    secretName: le-other-prod-wildcard-cert
+---
 # dockertest-ingress-1-whitelist
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
@@ -160,66 +276,6 @@ spec:
     - 1.2.3.0
     - 1.2.3.1
     - 1.2.3.4
----
-# ingress-https-route-0
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  labels:
-    name: dockertest
-    app.kubernetes.io/version: pr-1234
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: dockertest
-    app.kubernetes.io/instance: dockertest
-    maintainer: MPyL
-    version: pr-1234
-    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-ingress-0-https
-spec:
-  routes:
-  - kind: Rule
-    match: Host(`payments-1234.test.nl`)
-    services:
-    - name: dockertest
-      kind: Service
-      port: 8080
-    middlewares:
-    - name: dockertest-ingress-0-whitelist
-    - name: traefik-https-redirect@kubernetescrd
-  entryPoints:
-  - websecure
-  tls:
-    secretName: le-custom-prod-wildcard-cert
----
-# ingress-https-route-1
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  labels:
-    name: dockertest
-    app.kubernetes.io/version: pr-1234
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: dockertest
-    app.kubernetes.io/instance: dockertest
-    maintainer: MPyL
-    version: pr-1234
-    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-ingress-1-https
-spec:
-  routes:
-  - kind: Rule
-    match: Host(`some.other.host.com`)
-    services:
-    - name: dockertest
-      kind: Service
-      port: 4091
-    middlewares:
-    - name: dockertest-ingress-1-whitelist
-    - name: traefik-https-redirect@kubernetescrd
-  entryPoints:
-  - websecure
-  tls:
-    secretName: le-other-prod-wildcard-cert
 ---
 # prometheus-rule
 apiVersion: monitoring.coreos.com/v1

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -166,6 +166,9 @@ spec:
   - websecure
   tls:
     secretName: le-custom-prod-wildcard-cert
+    options:
+      name: insecure-ciphers
+      namespace: traefik
 ---
 # dockertest-ingress-0-whitelist
 apiVersion: traefik.containo.us/v1alpha1
@@ -218,6 +221,7 @@ spec:
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
+    priority: 1000
   entryPoints:
   - web
 ---
@@ -246,6 +250,7 @@ spec:
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
+    priority: 1000
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -36,6 +37,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: dockertest
         app.kubernetes.io/instance: dockertest
+        maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
         revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -119,6 +121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -147,6 +150,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -184,6 +188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -206,6 +211,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -235,6 +241,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -270,6 +277,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -292,6 +300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -329,6 +338,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -352,6 +362,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -391,6 +402,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -418,6 +430,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
@@ -433,6 +446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
+    maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -87,7 +87,7 @@ spec:
           periodSeconds: 30
           successThreshold: 0
           timeoutSeconds: 20
-        name: dockertest
+        name: service
         ports:
         - containerPort: 80
           name: port-0

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -164,7 +164,6 @@ spec:
       kind: Service
       port: 8080
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-0-whitelist
   entryPoints:
   - websecure
@@ -255,7 +254,6 @@ spec:
       kind: Service
       port: 4091
     middlewares:
-    - name: traefik-https-redirect@kubernetescrd
     - name: dockertest-ingress-1-whitelist
     priority: 1000
   entryPoints:

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -219,7 +219,7 @@ class TestKubernetesChart:
 
         route = to_service_chart(builder)
         assert (
-            DeployKubernetes.try_extract_hostname(route)
+            DeployKubernetes.try_extract_hostname(route, project.name)
             == "https://minimalservice-1234.test-backend.nl"
         )
 

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -47,7 +47,7 @@ class TestKubernetesChart:
         file_name: Path,
         chart: str,
         resources: dict[str, CustomResourceDefinition],
-        overwrite: bool = False,
+        overwrite: bool = True,
     ):
         name_chart = file_name / f"{chart}.yaml"
         resource = resources[chart]
@@ -154,8 +154,10 @@ class TestKubernetesChart:
             "service",
             "service-account",
             "sealed-secrets",
-            "ingress-https-route-0",
-            "ingress-https-route-1",
+            "dockertest-ingress-0-https",
+            "dockertest-ingress-0-http",
+            "dockertest-ingress-1-https",
+            "dockertest-ingress-1-http",
             "dockertest-ingress-0-whitelist",
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
@@ -173,8 +175,10 @@ class TestKubernetesChart:
             "sealed-secrets",
             "deployment",
             "service",
-            "ingress-https-route-0",
-            "ingress-https-route-1",
+            "dockertest-ingress-0-https",
+            "dockertest-ingress-0-http",
+            "dockertest-ingress-1-https",
+            "dockertest-ingress-1-http",
             "dockertest-ingress-0-whitelist",
             "dockertest-ingress-1-whitelist",
             "prometheus-rule",
@@ -190,21 +194,23 @@ class TestKubernetesChart:
         assert_roundtrip(
             self.k8s_resources_path / "templates" / "manifest.yaml",
             manifest,
-            overwrite=False,
+            overwrite=True,
         )
 
     def test_default_ingress(self):
         project = get_minimal_project()
         builder = self._get_builder(project)
         chart = to_service_chart(builder)
-        self._roundtrip(self.template_path / "ingress", "ingress-https-route-0", chart)
+        self._roundtrip(
+            self.template_path / "ingress", "minimalService-ingress-0-https", chart
+        )
 
     def test_production_ingress(self):
         project = get_minimal_project()
         builder = self._get_builder(project, test_data.RUN_PROPERTIES_PROD)
         chart = to_service_chart(builder)
         self._roundtrip(
-            self.template_path / "ingress-prod", "ingress-https-route-0", chart
+            self.template_path / "ingress-prod", "minimalService-ingress-0-https", chart
         )
 
     def test_ingress_to_urls(self):

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -47,7 +47,7 @@ class TestKubernetesChart:
         file_name: Path,
         chart: str,
         resources: dict[str, CustomResourceDefinition],
-        overwrite: bool = True,
+        overwrite: bool = False,
     ):
         name_chart = file_name / f"{chart}.yaml"
         resource = resources[chart]
@@ -194,7 +194,7 @@ class TestKubernetesChart:
         assert_roundtrip(
             self.k8s_resources_path / "templates" / "manifest.yaml",
             manifest,
-            overwrite=True,
+            overwrite=False,
         )
 
     def test_default_ingress(self):


### PR DESCRIPTION
- [x] Create HTTP ingress routes that redirect to the HTTPS one.
- [x] Add priority for routes
- [x] Add insecure option 
- [x] Set both maintainer and maintainers fields in the metadata
- [x] Use "service" as the default name of containers


----
### 📕 [TECH-694](https://vandebron.atlassian.net/browse/TECH-694) Add HTTP routes <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-299/3/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-299.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-299.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-299.test.nl/swagger/index.html)*, *sparkJob*  


[TECH-694]: https://vandebron.atlassian.net/browse/TECH-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ