### PR TITLE
[DATA-1165] Add env var to Docker Build

### DIFF
--- a/releases/notes/1.4.4.md
+++ b/releases/notes/1.4.4.md
@@ -3,3 +3,4 @@
 - Filter out override projects from the `projects` cli commands
 - Sort the `projects names` results alphabetically
 - Fix the fact that whitelists are being cached between charts/projects, thus subsequent charts/projects contain the whitelists from previous ones
+- Add default build_args for DockerBuild and DockerTest stages

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -89,7 +89,7 @@ class BuildDocker(Step):
             env_vars: set[str] = {
                 arg.secret_id for arg in build_config.args.credentials
             }
-            if missing := env_vars.difference(set(os.environ)):
+            if missing := env_vars.difference(set(os.environ).union(set(build_args.keys()))):
                 self._logger.error(
                     f"Project {step_input.project.name} requires {missing} environment variable(s) to be set"
                 )

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -75,7 +75,11 @@ class BuildDocker(Step):
             contents = "\n".join(DOCKER_IGNORE_DEFAULT)
             ignore_file.write(contents)
 
-        build_args: dict[str, str] = {}
+        build_args: dict[str, str] = {
+            "DOCKER_IMAGE": image_tag,
+            "MAINTAINER": ",".join(step_input.project.maintainer),
+            "TAG_NAME": step_input.run_properties.versioning.identifier,
+        }
         if build_config := step_input.project.build:
             build_args |= {
                 arg.key: arg.get_value(step_input.run_properties.target)

--- a/src/mpyl/steps/test/dockertest.py
+++ b/src/mpyl/steps/test/dockertest.py
@@ -80,7 +80,11 @@ class TestDocker(Step):
             image_tag=tag,
             target=test_target,
             registry_config=docker_registry_config,
-            build_args={},
+            build_args={
+                "DOCKER_IMAGE": tag,
+                "MAINTAINER": ",".join(step_input.project.maintainer),
+                "TAG_NAME": step_input.run_properties.versioning.identifier,
+            },
         )
 
         if success:

--- a/src/mpyl/steps/test/dockertest.py
+++ b/src/mpyl/steps/test/dockertest.py
@@ -39,6 +39,7 @@ from ...utilities.docker import (
     create_container,
     push_to_registry,
     registry_for_project,
+    get_default_build_args,
 )
 from ...utilities.junit import (
     to_test_suites,
@@ -80,11 +81,11 @@ class TestDocker(Step):
             image_tag=tag,
             target=test_target,
             registry_config=docker_registry_config,
-            build_args={
-                "DOCKER_IMAGE": tag,
-                "MAINTAINER": ",".join(step_input.project.maintainer),
-                "TAG_NAME": step_input.run_properties.versioning.identifier,
-            },
+            build_args=get_default_build_args(
+                tag,
+                step_input.project.maintainer,
+                step_input.run_properties.versioning.identifier,
+            ),
         )
 
         if success:

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -159,6 +159,16 @@ def docker_image_tag(step_input: Input) -> str:
     return f"{step_input.project.name.lower()}:{tag}".replace("/", "_")
 
 
+def get_default_build_args(
+    image_tag: str, maintainers: list[str], tag_name: str
+) -> dict[str, str]:
+    return {
+        "DOCKER_IMAGE": image_tag,
+        "MAINTAINER": ",".join(maintainers),
+        "TAG_NAME": tag_name,
+    }
+
+
 def docker_registry_path(docker_config: DockerRegistryConfig, image_name: str) -> str:
     path_components = [
         docker_config.host_name,


### PR DESCRIPTION


----
### 📕 [DATA-1165](https://vandebron.atlassian.net/browse/DATA-1165) CLONE - Migrate all dagster/scripting projects to be deployed with MPyL <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5e8c683bdc19850b871e0cc2/c5da54f4-57fa-4249-b7a1-a81b3ffc3716/24" width="24" height="24" alt="katringrunert@vandebron.nl" /> 
[2926](https://github.com/Vandebron/scripting/pull/2926)  needs to be merged first (linting and updating of runner and config)

----

to test the behaviour of two user-code repositories co-existing (MPL and MPyL dpeloyed) I would like to:

test out a usercode deployment on Acceptance:

* make backup of the workspace.yml file (copy YAML and store locally)
* deploy a tag with MPL (suf or so)
* then deploy the same tag with MPyL
* check if everything’s still working

the results of this test will decide whether a hard-switch for ALL projects is needed or what steps can be done to make a softer switch happen/.

----

check in with Tim (platform) about the workspace-configmap backup

----

check on how to deprecate a Jenkinspipeline?

----

* fix linting errors (check mpyl lint --all)
**** deprecate the kubernets.secrets tab once everything is fully running on MPyL

----

* schedule knowledge share for all affected teams

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-300/3/display/redirect) ✅ Successful, started by _Katrin Grunert_  
🚀 *[cloudfront-service](https://cloudfront-service-300.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-300.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-300.test.nl/swagger/index.html)*, *sparkJob*  


[DATA-1165]: https://vandebron.atlassian.net/browse/DATA-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ