### PR TITLE
feature/TECH 532 implement manual build selection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
                             sh "pipenv run mpyl projects upgrade"
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
+                            env.SELECTED_PROJECTS = ""
                             if (params.MANUAL_BUILD) {
                                 def projects = sh(script: "pipenv run mpyl projects names", returnStdout: true)
                                 def boolParams = projects.split('\n').collect { project ->

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline {
                 script {
                     properties([parameters([
                         string(name: 'BUILD_PARAMS', defaultValue: '--all', description: 'Build parameters passed along with the run. Example: --help or --all'),
-                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository')
+                        string(name: 'MPYL_CONFIG_BRANCH', defaultValue: 'main', description: 'Branch to use for mpyl_config repository'),
+                        booleanParam(name: 'MANUAL_BUILD', defaultValue: false, description: 'Enable manual project selection in the initialize phase'),
                     ])])
                     currentBuild.result = 'NOT_BUILT'
                     currentBuild.description = "Parameters can be set now"
@@ -49,6 +50,15 @@ pipeline {
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
                             sh "pipenv run mpyl build status"
+                            if (params.MANUAL_BUILD) {
+                                def projects = sh(script: "pipenv run mpyl projects names", returnStdout: true)
+                                def boolParams = projects.split('\n').collect { project ->
+                                    booleanParam(name: project, defaultValue: false)
+                                }
+                                def selectedProjects = input(id: 'userInput', message: 'Select project(s)', parameters: boolParams)
+                                def selectedProjectsString = selectedProjects.findAll { key, value -> value }.keySet().join(',')
+                                env.SELECTED_PROJECTS = "--projects " + selectedProjectsString
+                            }
                             sh "pipenv run start-github-status-check"
                         }
                     }
@@ -58,14 +68,14 @@ pipeline {
         stage('Build') {
             steps {
                 wrap([$class: 'BuildUser']) {
-                    sh "pipenv run mpyl build run --ci --stage build ${params.BUILD_PARAMS}"
+                    sh "pipenv run mpyl build run --ci --stage build ${params.BUILD_PARAMS} ${env.SELECTED_PROJECTS}"
                 }
             }
         }
         stage('Test') {
             steps {
                 wrap([$class: 'BuildUser']) {
-                    sh "pipenv run mpyl build run --ci --stage test --sequential ${params.BUILD_PARAMS}"
+                    sh "pipenv run mpyl build run --ci --stage test --sequential ${params.BUILD_PARAMS} ${env.SELECTED_PROJECTS}"
                 }
             }
         }
@@ -73,7 +83,7 @@ pipeline {
             steps {
                 withKubeConfig([credentialsId: 'jenkins-rancher-service-account-kubeconfig-test']) {
                     wrap([$class: 'BuildUser']) {
-                        sh "pipenv run mpyl build run --ci --stage deploy --sequential ${params.BUILD_PARAMS}"
+                        sh "pipenv run mpyl build run --ci --stage deploy --sequential ${params.BUILD_PARAMS} ${env.SELECTED_PROJECTS}"
                     }
                 }
             }
@@ -82,7 +92,7 @@ pipeline {
             steps {
                 withKubeConfig([credentialsId: 'jenkins-rancher-service-account-kubeconfig-test']) {
                     wrap([$class: 'BuildUser']) {
-                        sh "pipenv run mpyl build run --ci --stage postdeploy --sequential ${params.BUILD_PARAMS}"
+                        sh "pipenv run mpyl build run --ci --stage postdeploy --sequential ${params.BUILD_PARAMS} ${env.SELECTED_PROJECTS}"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,6 @@ pipeline {
                             sh "pipenv run mpyl projects upgrade"
                             sh "pipenv run mpyl repo status"
                             sh "pipenv run mpyl repo init"
-                            sh "pipenv run mpyl build status"
                             if (params.MANUAL_BUILD) {
                                 def projects = sh(script: "pipenv run mpyl projects names", returnStdout: true)
                                 def boolParams = projects.split('\n').collect { project ->
@@ -59,6 +58,7 @@ pipeline {
                                 def selectedProjectsString = selectedProjects.findAll { key, value -> value }.keySet().join(',')
                                 env.SELECTED_PROJECTS = "--projects " + selectedProjectsString
                             }
+                            sh "pipenv run mpyl build status ${env.SELECTED_PROJECTS} ${(env.BUILD_PARAMS.contains("--all")) ? "--all" : ""}"
                             sh "pipenv run start-github-status-check"
                         }
                     }

--- a/releases/notes/1.4.3.md
+++ b/releases/notes/1.4.3.md
@@ -1,0 +1,12 @@
+#### Manual project selection
+Allows for passing a comma separated string of projects to be passed to the run cli, using the `-p` or `--projects` 
+flags. This will override the default change detection behavior and the `-all` flag.
+
+#### Traefik configuration
+- Create HTTP ingress routes that redirect to the HTTPS one
+- Add priority for routes
+- Add insecure option
+
+#### Kubernetes configuration 
+- Set both maintainer and maintainers fields in the metadata
+- Use “service” as the default name of containers

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -1,7 +1,6 @@
 """Simple MPyL build runner"""
 
 import logging
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -27,7 +26,7 @@ from .steps.steps import Steps, ExecutionException
 from .utilities.repo import Revision, Repository, RepoConfig
 
 
-def print_status(obj: CliContext):
+def print_status(obj: CliContext, cli_params: MpylCliParameters):
     run_properties = RunProperties.from_configuration(obj.run_properties, obj.config)
     console = obj.console
     console.print(f"MPyL log level is set to {run_properties.console.log_level}")
@@ -70,7 +69,7 @@ def print_status(obj: CliContext):
         logger=logging.getLogger("mpyl"),
         repo=obj.repo,
         run_properties=run_properties,
-        cli_parameters=MpylCliParameters(local=sys.stdout.isatty()),
+        cli_parameters=cli_params,
     )
     if result.has_run_plan_projects:
         console.print(

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -106,6 +106,7 @@ def get_build_plan(
         cli_parameters.all,
         safe_load_projects,
         cli_parameters.stage,
+        cli_parameters.projects,
     )
     return RunResult(
         run_properties=run_properties,
@@ -191,6 +192,7 @@ def find_build_set(
     build_all: bool,
     safe_load_projects: bool,
     selected_stage: Optional[str] = None,
+    selected_projects: Optional[str] = None,
 ) -> dict[Stage, set[Project]]:
     project_paths = repo.find_projects()
     all_projects = set(
@@ -205,6 +207,8 @@ def find_build_set(
             project_paths,
         )
     )
+    if selected_projects:
+        projects_list = selected_projects.split(",")
 
     build_set = {}
 
@@ -212,7 +216,11 @@ def find_build_set(
         if selected_stage and selected_stage != stage.name:
             continue
 
-        if build_all:
+        if build_all or selected_projects:
+            if selected_projects:
+                all_projects = set(
+                    filter(lambda p: p.name in projects_list, all_projects)
+                )
             projects = for_stage(all_projects, stage)
         else:
             projects = find_invalidated_projects_for_stage(

--- a/src/mpyl/cli/__init__.py
+++ b/src/mpyl/cli/__init__.py
@@ -38,6 +38,7 @@ class MpylCliParameters:
     verbose: bool = False
     all: bool = False
     stage: Optional[str] = None
+    projects: Optional[str] = None
 
 
 async def get_publication_info(test: bool = False) -> dict:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -149,9 +149,16 @@ class CustomValidation(click.Command):
     required=False,
     help="Combine results with previous run(s)",
 )
+@click.option(
+    "--projects",
+    "--p",
+    type=str,
+    required=False,
+    help="Comma separated list of the projects to build",
+)
 @click.pass_obj
 def run(
-    obj: CliContext, ci, all_, tag, stage, sequential
+    obj: CliContext, ci, all_, tag, stage, sequential, projects
 ):  # pylint: disable=invalid-name
     asyncio.run(warn_if_update(obj.console))
 
@@ -162,6 +169,7 @@ def run(
         verbose=obj.verbose,
         tag=tag,
         stage=stage,
+        projects=projects,
     )
     obj.console.log(parameters)
 

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -213,12 +213,30 @@ def run(
 
 
 @build.command(help="The status of the current local branch from MPyL's perspective")
+@click.option(
+    "--all",
+    "all_",
+    is_flag=True,
+    help="Build all projects, regardless of changes on branch",
+)
+@click.option(
+    "--projects",
+    "--p",
+    type=str,
+    required=False,
+    help="Comma separated list of the projects to build",
+)
 @click.pass_obj
-def status(obj: CliContext):
+def status(obj: CliContext, all_, projects):
     upgrade_check = None
     try:
         upgrade_check = asyncio.wait_for(warn_if_update(obj.console), timeout=3)
-        print_status(obj)
+        parameters = MpylCliParameters(
+            local=sys.stdout.isatty(),
+            all=all_,
+            projects=projects,
+        )
+        print_status(obj, parameters)
     except asyncio.exceptions.TimeoutError:
         pass
     finally:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -221,7 +221,7 @@ def run(
 )
 @click.option(
     "--projects",
-    "--p",
+    "-p",
     type=str,
     required=False,
     help="Comma separated list of the projects to build",

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -151,7 +151,7 @@ class CustomValidation(click.Command):
 )
 @click.option(
     "--projects",
-    "--p",
+    "-p",
     type=str,
     required=False,
     help="Comma separated list of the projects to build",

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -88,6 +88,16 @@ def list_projects(obj: ProjectsContext):
         obj.cli.console.print(Markdown(f"{proj} `{name}`"))
 
 
+@projects.command(name="names", help="List found project names")
+@click.pass_obj
+def list_project_names(obj: ProjectsContext):
+    found_projects = obj.cli.repo.find_projects(obj.filter)
+
+    for proj in found_projects:
+        name = load_project(obj.cli.repo.root_dir, Path(proj), False).name
+        obj.cli.console.print(name)
+
+
 class ProjectPath(ParamType):
     name = "project_path"
 

--- a/tests/cli/test_resources/projects_help_text.txt
+++ b/tests/cli/test_resources/projects_help_text.txt
@@ -12,5 +12,6 @@ Options:
 Commands:
   lint     Validate the yaml of changed projects against their schema
   list     List found projects
+  names    List found project names
   show     Show details of a project
   upgrade  Upgrade projects to conform with the latest schema


### PR DESCRIPTION
- [TECH-532] Add support for manual project selection to the cli
- [TECH-532] Add manual project selection to the jenkinsfile


[TECH-532]: https://vandebron.atlassian.net/browse/TECH-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-532]: https://vandebron.atlassian.net/browse/TECH-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-532](https://vandebron.atlassian.net/browse/TECH-532) Figure out a manual build approach <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Valid issues to take care of:

* changes to libraries resulting in no file changes → security issue , need to rebuild and deploy
* building only a subset
* keeping all your projects up to date
* change to common pipeline code
* building other projects from a tag

🏗️ Build [8](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-301/8/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-301.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-301.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-301.test.nl/swagger/index.html)*, *sparkJob*  
