### PR TITLE
feature/TECH 652 fix spark deploy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -421,7 +421,8 @@ disable=raw-checker-failed,
         logging-fstring-interpolation,
         missing-class-docstring,
         missing-function-docstring,
-        too-many-instance-attributes
+        too-many-instance-attributes,
+        duplicate-code
 # TODO: re-enable documentation related lint checks
 
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -412,7 +412,9 @@ class ChartBuilder:
                 image=self._get_image(),
                 command=self.project.kubernetes.command.get_value(self.target).split(
                     " "
-                ),
+                )
+                if self.project.kubernetes.command
+                else None,
                 env_secret_key_refs={
                     s.key: {"key": s.key, "name": self.release_name}
                     for s in self.sealed_secrets

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -262,7 +262,7 @@ class ChartBuilder:
 
     def _to_object_meta(
         self, name: Optional[str] = None, annotations: Optional[dict] = None
-    ):
+    ) -> V1ObjectMeta:
         return V1ObjectMeta(
             name=name if name else self.release_name,
             labels=self._to_labels(),
@@ -403,6 +403,7 @@ class ChartBuilder:
 
     def to_spark_application(self) -> V1SparkApplication:
         return V1SparkApplication(
+            metadata=self._to_object_meta(),
             schedule=self._get_job().cron["schedule"],
             body=to_spark_body(
                 project_name=self.release_name,

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -410,6 +410,9 @@ class ChartBuilder:
                 env_vars=get_env_variables(self.project, self.target),
                 spark=self._get_job().spark,
                 image=self._get_image(),
+                command=self.project.kubernetes.command.get_value(self.target).split(
+                    " "
+                ),
             ),
         )
 

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -413,6 +413,10 @@ class ChartBuilder:
                 command=self.project.kubernetes.command.get_value(self.target).split(
                     " "
                 ),
+                env_secret_key_refs={
+                    s.key: {"key": s.key, "name": self.release_name}
+                    for s in self.sealed_secrets
+                },
             ),
         )
 

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -13,7 +13,7 @@ def to_spark_body(
     env_vars: dict,
     spark: dict,
     image: str,
-    command: list[str],
+    command: Optional[list[str]],
     env_secret_key_refs: dict,
 ) -> dict:
     static_body = {
@@ -24,7 +24,6 @@ def to_spark_body(
         "restartPolicy": {"type": "Never"},
         "sparkConfigMap": project_name,
         "image": image,
-        "arguments": command,
         "driver": {
             "cores": 1,
             "coreLimit": "1200m",
@@ -56,7 +55,7 @@ def to_spark_body(
             "spark.sql.legacy.timeParserPolicy": "LEGACY",
             "spark.sql.broadcastTimeout": "600",
         },
-    }
+    } | ({"arguments": command} if command else {})
 
     return static_body | spark
 

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -118,7 +118,11 @@ class V1SparkApplication(CustomResourceDefinition):
                 kind="ScheduledSparkApplication",
                 metadata=metadata,
                 schema="sparkoperator.k8s.io_scheduledsparkapplications.schema.yml",
-                spec={"schedule": schedule, "template": body},
+                spec={
+                    "concurrencyPolicy": "Forbid",
+                    "schedule": schedule,
+                    "template": body,
+                },
             )
         else:
             super().__init__(

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -111,12 +111,12 @@ def get_spark_config_map_data() -> dict:
 
 
 class V1SparkApplication(CustomResourceDefinition):
-    def __init__(self, schedule: Optional[str], body: dict):
+    def __init__(self, metadata: V1ObjectMeta, schedule: Optional[str], body: dict):
         if schedule:
             super().__init__(
                 api_version="sparkoperator.k8s.io/v1beta2",
                 kind="ScheduledSparkApplication",
-                metadata=V1ObjectMeta(name="sparkapplications.sparkoperator.k8s.io"),
+                metadata=metadata,
                 schema="sparkoperator.k8s.io_scheduledsparkapplications.schema.yml",
                 spec={"schedule": schedule, "template": body},
             )
@@ -124,7 +124,7 @@ class V1SparkApplication(CustomResourceDefinition):
             super().__init__(
                 api_version="sparkoperator.k8s.io/v1beta2",
                 kind="SparkApplication",
-                metadata=V1ObjectMeta(name="sparkapplications.sparkoperator.k8s.io"),
+                metadata=metadata,
                 schema="sparkoperator.k8s.io_sparkapplications.schema.yml",
                 spec={"spec": body},
             )

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -8,7 +8,9 @@ from kubernetes.client import V1ObjectMeta
 from .. import CustomResourceDefinition
 
 
-def to_spark_body(project_name: str, env_vars: dict, spark: dict, image: str) -> dict:
+def to_spark_body(
+    project_name: str, env_vars: dict, spark: dict, image: str, command: list[str]
+) -> dict:
     static_body = {
         "type": "Scala",
         "mode": "cluster",
@@ -17,11 +19,7 @@ def to_spark_body(project_name: str, env_vars: dict, spark: dict, image: str) ->
         "restartPolicy": {"type": "Never"},
         "sparkConfigMap": project_name,
         "image": image,
-        "arguments": [
-            "python",
-            "-m",
-            "job_testing_mpl_k8s.main_send_slack_notification",
-        ],
+        "arguments": command,
         "driver": {
             "cores": 1,
             "coreLimit": "1200m",

--- a/src/mpyl/steps/deploy/k8s/resources/spark.py
+++ b/src/mpyl/steps/deploy/k8s/resources/spark.py
@@ -9,7 +9,12 @@ from .. import CustomResourceDefinition
 
 
 def to_spark_body(
-    project_name: str, env_vars: dict, spark: dict, image: str, command: list[str]
+    project_name: str,
+    env_vars: dict,
+    spark: dict,
+    image: str,
+    command: list[str],
+    env_secret_key_refs: dict,
 ) -> dict:
     static_body = {
         "type": "Scala",
@@ -28,7 +33,7 @@ def to_spark_body(
             "labels": {"version": "3.1.1"},
             "serviceAccount": project_name,
             "envVars": env_vars,
-            "envSecretKeyRefs": None,
+            "envSecretKeyRefs": env_secret_key_refs,
         },
         "executor": {
             "cores": 1,
@@ -37,7 +42,7 @@ def to_spark_body(
             "memoryOverhead": "2048",
             "labels": {"version": "3.1.1"},
             "envVars": env_vars,
-            "envSecretKeyRefs": None,
+            "envSecretKeyRefs": env_secret_key_refs,
         },
         "deps": {
             "jars": [

--- a/src/mpyl/steps/deploy/kubernetes_spark_job.py
+++ b/src/mpyl/steps/deploy/kubernetes_spark_job.py
@@ -29,15 +29,14 @@ class DeployKubernetesSparkJob(Step):
 
     def execute(self, step_input: Input) -> Output:
         run_properties = step_input.run_properties
-        chart = to_spark_job_chart(
-            ChartBuilder(
-                step_input,
-                find_deploy_set(
-                    repo_config=RepoConfig.from_config(run_properties.config),
-                    tag=step_input.run_properties.versioning.tag,
-                ),
-            )
+        builder = ChartBuilder(
+            step_input,
+            find_deploy_set(
+                repo_config=RepoConfig.from_config(run_properties.config),
+                tag=step_input.run_properties.versioning.tag,
+            ),
         )
+        chart = to_spark_job_chart(builder)
         return deploy_helm_chart(
             self._logger,
             chart,

--- a/tests/cli/test_resources/list_projects_text.txt
+++ b/tests/cli/test_resources/list_projects_text.txt
@@ -7,4 +7,6 @@ tests/projects/job/deployment/project.yml [1;36;40mjob[0m
 tests/projects/overriden-project/deployment/project.yml [1;36;40mocpp[0m                    
 tests/projects/sbt-service/deployment/project.yml [1;36;40msbtservice[0m                    
 tests/projects/service/deployment/project.yml [1;36;40mnodeservice[0m                       
+tests/projects/spark-job/deployment/project-override-first.yml [1;36;40msparkJob-first[0m   
+tests/projects/spark-job/deployment/project-override-second.yml [1;36;40msparkJob-second[0m 
 tests/projects/spark-job/deployment/project.yml [1;36;40msparkJob[0m                        

--- a/tests/cli/test_resources/list_projects_text.txt
+++ b/tests/cli/test_resources/list_projects_text.txt
@@ -7,6 +7,4 @@ tests/projects/job/deployment/project.yml [1;36;40mjob[0m
 tests/projects/overriden-project/deployment/project.yml [1;36;40mocpp[0m                    
 tests/projects/sbt-service/deployment/project.yml [1;36;40msbtservice[0m                    
 tests/projects/service/deployment/project.yml [1;36;40mnodeservice[0m                       
-tests/projects/spark-job/deployment/project-override-first.yml [1;36;40msparkJob-first[0m   
-tests/projects/spark-job/deployment/project-override-second.yml [1;36;40msparkJob-second[0m 
 tests/projects/spark-job/deployment/project.yml [1;36;40msparkJob[0m                        

--- a/tests/projects/spark-job/deployment/project-override-first.yml
+++ b/tests/projects/spark-job/deployment/project-override-first.yml
@@ -1,0 +1,11 @@
+name: 'sparkJob-first'
+maintainer: ['MPyL']
+mpylVersion: 1.4.0
+stages:
+  deploy: Kubernetes Spark Job Deploy
+deployment:
+  namespace: jobs
+  properties:
+    env:
+      - key: INSTANCE
+        all: 'one'

--- a/tests/projects/spark-job/deployment/project-override-second.yml
+++ b/tests/projects/spark-job/deployment/project-override-second.yml
@@ -1,0 +1,11 @@
+name: 'sparkJob-second'
+maintainer: ['MPyL']
+mpylVersion: 1.4.0
+stages:
+  deploy: Kubernetes Spark Job Deploy
+deployment:
+  namespace: jobs
+  properties:
+    env:
+      - key: INSTANCE
+        all: 'two'

--- a/tests/projects/spark-job/deployment/project.yml
+++ b/tests/projects/spark-job/deployment/project.yml
@@ -1,7 +1,7 @@
 name: 'sparkJob'
 description: 'Job to enrich charge session with total amount earned'
 maintainer: ['MPyL']
-mpylVersion: 1.0.9
+mpylVersion: 1.4.0
 stages:
   build: Sbt Build
   test: Sbt Test
@@ -41,8 +41,6 @@ deployment:
           all: 1.0
         mem:
           all: 2048
-    policies:
-      - 'star-readonly'
     role:
       resources:
         - 'pods'

--- a/tests/projects/spark-job/deployment/project.yml
+++ b/tests/projects/spark-job/deployment/project.yml
@@ -5,7 +5,6 @@ mpylVersion: 1.0.9
 stages:
   build: Sbt Build
   test: Sbt Test
-  deploy: Kubernetes Spark Job Deploy
 deployment:
   namespace: 'jobs'
   properties:

--- a/tests/steps/deploy/k8s/chart/templates/spark/sealed-secrets.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/sealed-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: 'true'
+  labels:
+    chart: service-0.1.0
+  name: sparkjob
+spec:
+  encryptedData:
+    SEALED_SECRET: hash

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -42,6 +42,10 @@ spec:
         VAULT_ENABLED: 'true'
         DEPLOY_MODE: cluster
         ELASTICSEARCH_HOST: elastic-es-http.elastic
+      envSecretKeyRefs:
+        SEALED_SECRET:
+          key: SEALED_SECRET
+          name: sparkjob
     executor:
       cores: 1
       instances: 1
@@ -56,6 +60,10 @@ spec:
         VAULT_ENABLED: 'true'
         DEPLOY_MODE: cluster
         ELASTICSEARCH_HOST: elastic-es-http.elastic
+      envSecretKeyRefs:
+        SEALED_SECRET:
+          key: SEALED_SECRET
+          name: sparkjob
     deps:
       jars:
       - https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/11.2.1.jre8/mssql-jdbc-11.2.1.jre8.jar

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -13,6 +13,7 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: sparkjob
 spec:
+  concurrencyPolicy: Forbid
   schedule: 0 7 * * *
   template:
     type: Scala

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -24,9 +24,6 @@ spec:
       type: Never
     sparkConfigMap: sparkjob
     image: registry/image:123
-    arguments:
-    - run
-    - command
     driver:
       cores: 1
       coreLimit: 1200m
@@ -72,5 +69,8 @@ spec:
       spark.executor.extraClassPath: mssql-jdbc-11.2.1.jre8.jar
       spark.sql.legacy.timeParserPolicy: LEGACY
       spark.sql.broadcastTimeout: '600'
+    arguments:
+    - run
+    - command
     mainClass: sparkjob.sparkJobMain
     mainApplicationFile: local:///app/sparkjob-assembly-1.0.jar

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -25,9 +25,8 @@ spec:
     sparkConfigMap: sparkjob
     image: registry/image:123
     arguments:
-    - python
-    - -m
-    - job_testing_mpl_k8s.main_send_slack_notification
+    - run
+    - command
     driver:
       cores: 1
       coreLimit: 1200m

--- a/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/spark/spark.yaml
@@ -1,7 +1,17 @@
 apiVersion: sparkoperator.k8s.io/v1beta2
 kind: ScheduledSparkApplication
 metadata:
-  name: sparkapplications.sparkoperator.k8s.io
+  labels:
+    name: sparkjob
+    app.kubernetes.io/version: pr-1234
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: sparkjob
+    app.kubernetes.io/instance: sparkjob
+    maintainers: MPyL
+    maintainer: MPyL
+    version: pr-1234
+    revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
+  name: sparkjob
 spec:
   schedule: 0 7 * * *
   template:

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -248,7 +248,14 @@ class TestKubernetesChart:
 
     @pytest.mark.parametrize(
         "template",
-        ["spark", "service-account", "config-map", "role", "rolebinding"],
+        [
+            "spark",
+            "service-account",
+            "config-map",
+            "role",
+            "rolebinding",
+            "sealed-secrets",
+        ],
     )
     def test_spark_chart_roundtrip(self, template):
         builder = self._get_builder(get_spark_project())

--- a/tests/test_resources/test_spark_project.yml
+++ b/tests/test_resources/test_spark_project.yml
@@ -24,6 +24,9 @@ deployment:
         all: "cluster"
       - key: ELASTICSEARCH_HOST
         all: "elastic-es-http.elastic"
+    sealedSecret:
+      - key: SEALED_SECRET
+        all: "hash"
   kubernetes:
     job:
       activeDeadlineSeconds:

--- a/tests/test_resources/test_spark_project.yml
+++ b/tests/test_resources/test_spark_project.yml
@@ -33,6 +33,8 @@ deployment:
       spark:
         mainClass: "sparkjob.sparkJobMain"
         mainApplicationFile: "local:///app/sparkjob-assembly-1.0.jar"
+    command:
+      all: 'run command'
     resources:
       instances:
         all: 2


### PR DESCRIPTION
- [TECH-652] make sparkjob overriden
- [TECH-652] Pass metadata to spark job construction


[TECH-652]: https://vandebron.atlassian.net/browse/TECH-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-652]: https://vandebron.atlassian.net/browse/TECH-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-652](https://vandebron.atlassian.net/browse/TECH-652) Fix spark job deploy <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-302/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-302.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-302.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-302.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  
