### PR TITLE
feature/TECH 699 fix projects cli

### DIFF
--- a/releases/notes/1.4.4.md
+++ b/releases/notes/1.4.4.md
@@ -1,0 +1,4 @@
+#### Bugfixes
+
+- Filter out override projects from the `projects` cli commands
+- Sort the `projects names` results alphabetically

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -160,6 +160,10 @@ class CustomValidation(click.Command):
 def run(
     obj: CliContext, ci, all_, tag, stage, sequential, projects
 ):  # pylint: disable=invalid-name
+    run_result_file = Path(BUILD_ARTIFACTS_FOLDER) / "run_result"
+    if not sequential and run_result_file.is_file():
+        run_result_file.unlink()
+
     asyncio.run(warn_if_update(obj.console))
 
     parameters = MpylCliParameters(
@@ -193,12 +197,12 @@ def run(
             obj.run_properties["stages"],
         )
     )
+
     run_result = run_mpyl(
         run_properties=run_properties, cli_parameters=parameters, reporter=None
     )
 
     Path(BUILD_ARTIFACTS_FOLDER).mkdir(parents=True, exist_ok=True)
-    run_result_file = Path(BUILD_ARTIFACTS_FOLDER) / "run_result"
 
     if sequential and run_result_file.is_file():
         with open(run_result_file, "rb") as file:

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -78,14 +78,18 @@ def projects(ctx, config, verbose, filter_):
     )
 
 
+OVERRIDE_PATTERN = "project-override"
+
+
 @projects.command(name="list", help="List found projects")
 @click.pass_obj
 def list_projects(obj: ProjectsContext):
     found_projects = obj.cli.repo.find_projects(obj.filter)
 
     for proj in found_projects:
-        name = load_project(obj.cli.repo.root_dir, Path(proj), False).name
-        obj.cli.console.print(Markdown(f"{proj} `{name}`"))
+        if OVERRIDE_PATTERN not in proj:
+            project = load_project(obj.cli.repo.root_dir, Path(proj), False)
+            obj.cli.console.print(Markdown(f"{proj} `{project.name}`"))
 
 
 @projects.command(name="names", help="List found project names")
@@ -93,8 +97,15 @@ def list_projects(obj: ProjectsContext):
 def list_project_names(obj: ProjectsContext):
     found_projects = obj.cli.repo.find_projects(obj.filter)
 
-    for proj in found_projects:
-        name = load_project(obj.cli.repo.root_dir, Path(proj), False).name
+    names = sorted(
+        [
+            load_project(obj.cli.repo.root_dir, Path(proj), False).name
+            for proj in found_projects
+            if OVERRIDE_PATTERN not in proj
+        ]
+    )
+
+    for name in names:
         obj.cli.console.print(name)
 
 

--- a/tests/cli/test_resources/list_projects_text.txt
+++ b/tests/cli/test_resources/list_projects_text.txt
@@ -4,10 +4,6 @@ tests/projects/dagster-user-code/deployment/project.yml
 [1;36;40mexample-dagster-user-code[0m                                                       
 tests/projects/ephemeral/deployment/project.yml [1;36;40mkong-sync[0m                       
 tests/projects/job/deployment/project.yml [1;36;40mjob[0m                                   
-tests/projects/overriden-project/deployment/project-override-first.yml          
-[1;36;40mocpp-first[0m                                                                      
-tests/projects/overriden-project/deployment/project-override-second.yml         
-[1;36;40mocpp-second[0m                                                                     
 tests/projects/overriden-project/deployment/project.yml [1;36;40mocpp[0m                    
 tests/projects/sbt-service/deployment/project.yml [1;36;40msbtservice[0m                    
 tests/projects/service/deployment/project.yml [1;36;40mnodeservice[0m                       


### PR DESCRIPTION
- [TECH-699] Filter override projects out of the projects cli and sort the names
- [TECH-699] Add release notes for v1.4.4.


[TECH-699]: https://vandebron.atlassian.net/browse/TECH-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-699]: https://vandebron.atlassian.net/browse/TECH-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-699](https://vandebron.atlassian.net/browse/TECH-699) Fix projects cli <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 


🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-305/3/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-305.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-305.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-305.test.nl/swagger/index.html)*, *sparkJob*  
