### PR TITLE
feature/TECH 700 fix whitelists

### DIFF
--- a/releases/notes/1.4.4.md
+++ b/releases/notes/1.4.4.md
@@ -2,3 +2,4 @@
 
 - Filter out override projects from the `projects` cli commands
 - Sort the `projects names` results alphabetically
+- Fix the fact that whitelists are being cached between charts/projects, thus subsequent charts/projects contain the whitelists from previous ones

--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -464,7 +464,7 @@ class ChartBuilder:
         ) -> dict[str, list[str]]:
             white_lists = self.config_defaults.white_lists.default
             if configured and configured.get_value(self.target):
-                white_lists.extend(configured.get_value(self.target))
+                white_lists = white_lists + configured.get_value(self.target)
 
             return dict(
                 filter(lambda x: x[0] in white_lists, address_dictionary.items())

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -3,8 +3,6 @@ kind: Middleware
 metadata:
   annotations:
     VPN: 10.0.0.1
-    K8s-Test: 1.2.3.0, 1.2.3.1
-    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -20,6 +18,3 @@ spec:
   ipWhiteList:
     sourceRange:
     - 10.0.0.1
-    - 1.2.3.0
-    - 1.2.3.1
-    - 1.2.3.4

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -179,8 +179,6 @@ kind: Middleware
 metadata:
   annotations:
     VPN: 10.0.0.1
-    K8s-Test: 1.2.3.0, 1.2.3.1
-    TargetSpecificWhitelist: 1.2.3.4
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -196,9 +194,6 @@ spec:
   ipWhiteList:
     sourceRange:
     - 10.0.0.1
-    - 1.2.3.0
-    - 1.2.3.1
-    - 1.2.3.4
 ---
 # dockertest-ingress-1-http
 apiVersion: traefik.containo.us/v1alpha1


### PR DESCRIPTION
- [TECH-700] Make sure whitelists are not persisted between charts/projects
- [TECH-700] Add a release note about the whitelists bug
- [TECH-700] Update the unit tests related to whitelists


[TECH-700]: https://vandebron.atlassian.net/browse/TECH-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-700]: https://vandebron.atlassian.net/browse/TECH-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-700]: https://vandebron.atlassian.net/browse/TECH-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
### 📕 [TECH-700](https://vandebron.atlassian.net/browse/TECH-700) Fix whitelists in multiprojects deployments <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Whitelists are persisted in the mpyl code, which creates the issue that sequential projects/charts take the whitelists from previous charts/projects.

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-306/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-306.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-306.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-306.test.nl/swagger/index.html)*, *sparkJob*  
