### PR TITLE
[DATA-1165] Global serviceaccountname override possibility for dagster helm charts

### DIFF
--- a/releases/notes/1.4.5.md
+++ b/releases/notes/1.4.5.md
@@ -1,0 +1,3 @@
+#### Override option for dagster user deployments' helm charts
+
+- Enable users to override the serviceAccount in the user deployment helm chart of dagster with a global serviceAccount

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -449,3 +449,6 @@ definitions:
       webserver:
         description: "Name of the kubernetes instance that runs the dagster web UI, default"
         type: string
+      globalServiceAccountOverride:
+        description: "Name of an (external) serviceAccount that will be assigned to a dagster user-deployment in favor of creating a new one"
+        type: string

--- a/src/mpyl/steps/deploy/dagster.py
+++ b/src/mpyl/steps/deploy/dagster.py
@@ -104,6 +104,7 @@ class DeployDagster(Step):
             project=step_input.project,
             name_suffix=name_suffix,
             run_properties=properties,
+            service_account_override=dagster_config.global_service_account_override,
             docker_config=DockerConfig.from_dict(properties.config),
         )
 

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -2,6 +2,7 @@
 This module contains the Dagster user-code-deployment values conversion
 """
 from dataclasses import dataclass
+from typing import Optional
 
 from .....project import Project, get_env_variables
 from .....steps.models import RunProperties
@@ -18,13 +19,19 @@ def to_user_code_values(
     project: Project,
     name_suffix: str,
     run_properties: RunProperties,
+    service_account_override: Optional[str],
     docker_config: DockerConfig,
 ) -> dict:
     docker_registry = registry_for_project(docker_config, project)
-    return {
-        "global": {
-            "serviceAccountName": "user-code-dagster-user-deployments-user-deployments"
-        },
+
+    global_override = {}
+    create_local_service_account = service_account_override is None
+    if not create_local_service_account:
+        global_override = {"global": {"serviceAccountName": service_account_override}}
+
+    return global_override | {
+        "serviceAccount": {"create": create_local_service_account},
+        "nameOverride": "ucd",  # short for user-code-deployment
         "deployments": [
             {
                 "dagsterApiGrpcArgs": ["--python-file", project.dagster.repo],
@@ -41,8 +48,6 @@ def to_user_code_values(
                 "port": 3030,
             },
         ],
-        "serviceAccount": {"create": False},
-        "nameOverride": "ucd",  # short for user-code-deployment
     }
 
 

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -22,6 +22,9 @@ def to_user_code_values(
 ) -> dict:
     docker_registry = registry_for_project(docker_config, project)
     return {
+        "global": {
+            "serviceAccountName": "user-code-dagster-user-deployments-user-deployments"
+        },
         "deployments": [
             {
                 "dagsterApiGrpcArgs": ["--python-file", project.dagster.repo],
@@ -38,6 +41,7 @@ def to_user_code_values(
                 "port": 3030,
             },
         ],
+        "serviceAccount": {"create": False},
         "nameOverride": "ucd",  # short for user-code-deployment
     }
 

--- a/src/mpyl/utilities/dagster/__init__.py
+++ b/src/mpyl/utilities/dagster/__init__.py
@@ -2,7 +2,7 @@
 Dagster-related utility methods
 """
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
 
 
 @dataclass(frozen=True)
@@ -12,6 +12,7 @@ class DagsterConfig:
     workspace_file_key: str
     daemon: str
     webserver: str
+    global_service_account_override: Optional[str]
 
     @staticmethod
     def from_dict(config: Dict):
@@ -23,6 +24,9 @@ class DagsterConfig:
                 workspace_file_key=dagster_config["workspaceFileKey"],
                 daemon=dagster_config["daemon"],
                 webserver=dagster_config["webserver"],
+                global_service_account_override=dagster_config.get(
+                    "globalServiceAccountOverride", None
+                ),
             )
         except KeyError as exc:
             raise KeyError(f"Dagster config could not be loaded from {config}") from exc

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values.yaml
@@ -1,3 +1,5 @@
+global:
+  serviceAccountName: user-code-dagster-user-deployments-user-deployments
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file
@@ -16,4 +18,6 @@ deployments:
     enabled: true
   name: example-dagster-user-code-pr-1234
   port: 3030
+serviceAccount:
+  create: false
 nameOverride: ucd

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
@@ -1,0 +1,23 @@
+global:
+  serviceAccountName: global_service_account
+serviceAccount:
+  create: false
+nameOverride: ucd
+deployments:
+- dagsterApiGrpcArgs:
+  - --python-file
+  - /tests/projects/dagster-user-code/main.py
+  env:
+    DEPLOY_ENV: test
+    LOGGING_LEVEL: DEBUG
+  envSecrets: []
+  image:
+    pullPolicy: Always
+    imagePullSecrets:
+    - name: bigdataregistry
+    tag: pr-1234
+    repository: docker_host/example-dagster-user-code
+  includeConfigInLaunchedRuns:
+    enabled: true
+  name: example-dagster-user-code-pr-1234
+  port: 3030

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
@@ -1,5 +1,6 @@
-global:
-  serviceAccountName: user-code-dagster-user-deployments-user-deployments
+serviceAccount:
+  create: true
+nameOverride: ucd
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file
@@ -18,6 +19,3 @@ deployments:
     enabled: true
   name: example-dagster-user-code-pr-1234
   port: 3030
-serviceAccount:
-  create: false
-nameOverride: ucd

--- a/tests/steps/deploy/dagster/test_dagster.py
+++ b/tests/steps/deploy/dagster/test_dagster.py
@@ -32,7 +32,7 @@ class TestDagster:
         name_chart = file_name / f"{chart}.yaml"
         assert_roundtrip(name_chart, yaml_to_string(actual_values, yaml), overwrite)
 
-    def test_generate_correct_values_yaml(self):
+    def test_generate_correct_values_yaml_with_service_account_override(self):
         step_input = Input(
             load_project(self.resource_path, Path("project.yml"), True),
             test_data.RUN_PROPERTIES,
@@ -43,9 +43,33 @@ class TestDagster:
             project=step_input.project,
             name_suffix="-pr-1234",
             run_properties=test_data.RUN_PROPERTIES,
+            service_account_override="global_service_account",
             docker_config=DockerConfig.from_dict(
                 parse_config(Path(f"{self.config_resource_path}/mpyl_config.yml"))
             ),
         )
 
-        self._roundtrip(self.generated_values_path, "values", values)
+        self._roundtrip(
+            self.generated_values_path, "values_with_global_service_account", values
+        )
+
+    def test_generate_correct_values_yaml_without_service_account_override(self):
+        step_input = Input(
+            load_project(self.resource_path, Path("project.yml"), True),
+            test_data.RUN_PROPERTIES,
+            None,
+        )
+
+        values = to_user_code_values(
+            project=step_input.project,
+            name_suffix="-pr-1234",
+            run_properties=test_data.RUN_PROPERTIES,
+            service_account_override=None,
+            docker_config=DockerConfig.from_dict(
+                parse_config(Path(f"{self.config_resource_path}/mpyl_config.yml"))
+            ),
+        )
+
+        self._roundtrip(
+            self.generated_values_path, "values_without_global_service_account", values
+        )


### PR DESCRIPTION
This is to recreate the current behaviour of MPL's DagsterDeploy step of having one single serviceAccount for all dagster user deployment helm charts.

The override ServiceAccount can be configured via `mpyl_config`

For example: FTS's user deployment needs to be able to access resources in a different namespace in order to spawn their scheduled pods. With the base ServiceAccount that the dagster user deployment helm chart is creating, this is not possible, as it doesnt have the ClusterroleBindings that require this kind of action. The ClusterroleBindings are being created and maintained by the platform team. 

----
### 📕 [DATA-116](https://vandebron.atlassian.net/browse/DATA-116) KNMI HARMONIE model update <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/5dc92b5e97a0a20c663fdafe/c35a101b-4b00-4fc2-a5ac-8df486647a6f/24" width="24" height="24" alt="nilsterpstra@vandebron.nl" /> 
This EPIC replaces [ESFA-851](https://vandebron.atlassian.net/browse/ESFA-851) 

**Why**

KNMI will upgrade their current HARMONIE model, which means that we’ll have to also adopt our KNMI fetching pipeline, to be able to handle this new model. Current status of the project can be read in this email excerpt:

```
Improvements HARMONIE coming this summer

The popular weather forecasting model, HARMONIE, is set to receive a major upgrade this summer thanks to the use of the new powerful supercomputer. 
This update will bring higher resolution and the addition of new parameters, resulting in a more detailed and accurate forecast model. 
In February the first tests will be run, and in the summer the new version will be published on KDP. 
The new version will run in parallel with the current version for three months to ensure a smooth transition. 
Meteorologists and the public alike can expect even more reliable and accurate weather predictions with the new and improved version of the model. 

Stay tuned for more information on the specific changes and release date of the updated model. 
```

[vier-landen-bundelen-krachten-voor-betere-weersverwachting](https://www.knmi.nl/over-het-knmi/nieuws/vier-landen-bundelen-krachten-voor-betere-weersverwachting) 

🏗️ Build [5](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-308/5/display/redirect) ✅ Successful, started by _Katrin Grunert_  
🚀 *[cloudfront-service](https://cloudfront-service-308.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-308.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-308.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[DATA-116]: https://vandebron.atlassian.net/browse/DATA-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESFA-851]: https://vandebron.atlassian.net/browse/ESFA-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ