### PR TITLE
[TECH-706] Fail after all extended checks are run

### DIFF
--- a/releases/notes/1.4.6.md
+++ b/releases/notes/1.4.6.md
@@ -1,0 +1,4 @@
+#### Linting
+
+- Enable extended checks by default
+- Fail command if one of the extended checks fail

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -80,7 +80,7 @@ def _assert_correct_project_linkup(
     projects: list[Project],
     all_projects: list[Project],
     pr_identifier: Optional[int],
-):
+) -> bool:
     console.print("")
     console.print("Checking namespace substitution: ")
     wrong_substitutions = __get_wrong_substitutions_per_project(
@@ -88,8 +88,10 @@ def _assert_correct_project_linkup(
     )
     if len(wrong_substitutions) == 0:
         console.print("  ✅ No wrong namespace substitutions found")
+        return False
     else:
         __detail_wrong_substitutions(console, all_projects, wrong_substitutions)
+        return True
 
 
 def __get_wrong_substitutions_per_project(
@@ -142,7 +144,7 @@ def _lint_whitelisting_rules(
     projects: list[Project],
     config: dict,
     target: Target,
-):
+) -> bool:
     console.print("")
     console.print(f"Checking whitelisting rules for target {target}: ")
     defined_whitelists: set[str] = set(
@@ -169,6 +171,8 @@ def _lint_whitelisting_rules(
                     wrong_whitelists.append((project, diff))
     if len(wrong_whitelists) == 0:
         console.print("  ✅ No undefined whitelists found")
+        return False
     else:
         for project, diff in wrong_whitelists:
             console.log(f"  ❌ Project {project.name} has undefined whitelists: {diff}")
+        return True

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -80,18 +80,13 @@ def _assert_correct_project_linkup(
     projects: list[Project],
     all_projects: list[Project],
     pr_identifier: Optional[int],
-) -> bool:
+) -> list[WrongLinkupPerProject]:
     console.print("")
     console.print("Checking namespace substitution: ")
     wrong_substitutions = __get_wrong_substitutions_per_project(
         all_projects, projects, pr_identifier, target
     )
-    if len(wrong_substitutions) == 0:
-        console.print("  ✅ No wrong namespace substitutions found")
-        return False
-
-    __detail_wrong_substitutions(console, all_projects, wrong_substitutions)
-    return True
+    return wrong_substitutions
 
 
 def __get_wrong_substitutions_per_project(
@@ -144,13 +139,13 @@ def _lint_whitelisting_rules(
     projects: list[Project],
     config: dict,
     target: Target,
-) -> bool:
+) -> list[tuple[Project, set[str]]]:
     console.print("")
     console.print(f"Checking whitelisting rules for target {target}: ")
     defined_whitelists: set[str] = set(
         map(lambda rule: rule["name"], config["whiteLists"]["addresses"])
     )
-    wrong_whitelists: list[tuple[Project, set]] = []
+    wrong_whitelists: list[tuple[Project, set[str]]] = []
     for project in projects:
         if project.deployment:
             if traefik := project.deployment.traefik:
@@ -169,10 +164,5 @@ def _lint_whitelisting_rules(
                 )
                 if diff := whitelists.difference(defined_whitelists):
                     wrong_whitelists.append((project, diff))
-    if len(wrong_whitelists) == 0:
-        console.print("  ✅ No undefined whitelists found")
-        return False
 
-    for project, diff in wrong_whitelists:
-        console.log(f"  ❌ Project {project.name} has undefined whitelists: {diff}")
-    return True
+    return wrong_whitelists

--- a/src/mpyl/cli/commands/projects/lint.py
+++ b/src/mpyl/cli/commands/projects/lint.py
@@ -89,9 +89,9 @@ def _assert_correct_project_linkup(
     if len(wrong_substitutions) == 0:
         console.print("  ✅ No wrong namespace substitutions found")
         return False
-    else:
-        __detail_wrong_substitutions(console, all_projects, wrong_substitutions)
-        return True
+
+    __detail_wrong_substitutions(console, all_projects, wrong_substitutions)
+    return True
 
 
 def __get_wrong_substitutions_per_project(
@@ -172,7 +172,7 @@ def _lint_whitelisting_rules(
     if len(wrong_whitelists) == 0:
         console.print("  ✅ No undefined whitelists found")
         return False
-    else:
-        for project, diff in wrong_whitelists:
-            console.log(f"  ❌ Project {project.name} has undefined whitelists: {diff}")
-        return True
+
+    for project, diff in wrong_whitelists:
+        console.log(f"  ❌ Project {project.name} has undefined whitelists: {diff}")
+    return True


### PR DESCRIPTION
branch: feature/TECH-706_fail_on_extended_lint

----
### 📕 [TECH-706](https://vandebron.atlassian.net/browse/TECH-706) Improve linting <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-313/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-313.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-313.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-313.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-706]: https://vandebron.atlassian.net/browse/TECH-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ