### PR TITLE
[TECH-702] Explain build status

### DIFF
--- a/releases/notes/1.4.8.md
+++ b/releases/notes/1.4.8.md
@@ -1,8 +1,8 @@
 #### Discovery
 
-- Add debug logging to build plan discovery methods
-- This provides more explanation on _why_ certain projects are selected for each stage
-- Can be invoked by setting the `--verbose` for the `build` subcommand, e.g. `mpyl build --verbose status`
+Add debug logging to build plan discovery methods
+This provides more explanation on _why_ certain projects are selected for each stage
+Can be invoked by setting the `--verbose` for the `build` subcommand, e.g. `mpyl build --verbose status`
 
 #### Bug fixes
 - Add `command` and `args` fields to Kubernetes jobs

--- a/releases/notes/1.4.8.md
+++ b/releases/notes/1.4.8.md
@@ -1,0 +1,11 @@
+#### Discovery
+
+- Add debug logging to build plan discovery methods
+- This provides more explanation on _why_ certain projects are selected for each stage
+- Can be invoked by setting the `--verbose` for the `build` subcommand, e.g. `mpyl build --verbose status`
+
+#### Bug fixes
+
+- Fixes a bug when a non-changed project is selected whose base path includes fully a changed file's path.
+I.e. when the changed file is `projects/project-name/src/main.py` and a project's base path is `projects/project-name-other`,
+this other project was wrongly selected as changed.

--- a/src/mpyl/__init__.py
+++ b/src/mpyl/__init__.py
@@ -42,6 +42,6 @@ def add_commands():
 
 
 def main():
-    _disable_package_loggers(["markdown"])
+    _disable_package_loggers(["markdown", "asyncio"])
     add_commands()
     main_group()  # pylint: disable = no-value-for-parameter

--- a/src/mpyl/__init__.py
+++ b/src/mpyl/__init__.py
@@ -22,7 +22,7 @@ from .utilities.repo import RepoConfig, Repository
 
 
 def _disable_package_loggers(offending_loggers: list[str]):
-    for name, _ in logging.root.manager.loggerDict.items():  # disable = no-member
+    for name, _ in logging.root.manager.loggerDict.items():  # pylint: disable=no-member
         for offending_logger in offending_loggers:
             if name.startswith(offending_logger):
                 logging.getLogger(name).setLevel(logging.WARNING)

--- a/src/mpyl/__init__.py
+++ b/src/mpyl/__init__.py
@@ -7,6 +7,7 @@
 
 .. include:: ../../releases/README.md
 """
+import logging
 
 import click
 
@@ -18,6 +19,13 @@ from .cli.projects import projects
 from .cli.repository import repository
 from .utilities.pyaml_env import parse_config
 from .utilities.repo import RepoConfig, Repository
+
+
+def _disable_package_loggers(offending_loggers: list[str]):
+    for name, _ in logging.root.manager.loggerDict.items():
+        for offending_logger in offending_loggers:
+            if name.startswith(offending_logger):
+                logging.getLogger(name).setLevel(logging.WARNING)
 
 
 @click.group(name="mpyl", help="Command Line Interface for MPyL")
@@ -34,5 +42,6 @@ def add_commands():
 
 
 def main():
+    _disable_package_loggers(["markdown"])
     add_commands()
     main_group()  # pylint: disable = no-value-for-parameter

--- a/src/mpyl/__init__.py
+++ b/src/mpyl/__init__.py
@@ -22,7 +22,7 @@ from .utilities.repo import RepoConfig, Repository
 
 
 def _disable_package_loggers(offending_loggers: list[str]):
-    for name, _ in logging.root.manager.loggerDict.items():
+    for name, _ in logging.root.manager.loggerDict.items():  # disable = no-member
         for offending_logger in offending_loggers:
             if name.startswith(offending_logger):
                 logging.getLogger(name).setLevel(logging.WARNING)

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -99,6 +99,7 @@ def get_build_plan(
     logger.debug(f"Changes: {changes}")
 
     projects_per_stage: dict[Stage, set[Project]] = find_build_set(
+        logger,
         repo,
         changes,
         run_properties.stages,
@@ -185,6 +186,7 @@ def run_mpyl(
 
 
 def find_build_set(
+    logger: logging.Logger,
     repo: Repository,
     changes_in_branch: list[Revision],
     stages: list[Stage],
@@ -223,7 +225,10 @@ def find_build_set(
             projects = for_stage(all_projects, stage)
         else:
             projects = find_invalidated_projects_for_stage(
-                all_projects, stage.name, changes_in_branch
+                logger, all_projects, stage.name, changes_in_branch
+            )
+            logger.debug(
+                f"Invalidated projects for stage {stage.name}: {[p.name for p in projects]}"
             )
 
         build_set.update({stage: projects})

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -600,7 +600,7 @@ def validate_project(yaml_values: dict) -> dict:
 def get_project_root_dir(project_path: str) -> str:
     if project_path.endswith(".yml"):
         try:
-            return str(Path(project_path).parents[1])
+            return str(Path(project_path).parents[1]) + "/"
         except IndexError:
             pass
     return project_path

--- a/src/mpyl/steps/deploy/kubernetes.py
+++ b/src/mpyl/steps/deploy/kubernetes.py
@@ -53,6 +53,7 @@ class DeployKubernetes(Step):
         builder = ChartBuilder(
             step_input,
             find_deploy_set(
+                logger=self._logger,
                 repo_config=RepoConfig.from_config(properties.config),
                 tag=step_input.run_properties.versioning.tag,
             ),

--- a/src/mpyl/steps/deploy/kubernetes_job.py
+++ b/src/mpyl/steps/deploy/kubernetes_job.py
@@ -30,6 +30,7 @@ class DeployKubernetesJob(Step):
         builder = ChartBuilder(
             step_input,
             find_deploy_set(
+                logger=self._logger,
                 repo_config=RepoConfig.from_config(run_properties.config),
                 tag=step_input.run_properties.versioning.tag,
             ),

--- a/src/mpyl/steps/deploy/kubernetes_spark_job.py
+++ b/src/mpyl/steps/deploy/kubernetes_spark_job.py
@@ -32,6 +32,7 @@ class DeployKubernetesSparkJob(Step):
         builder = ChartBuilder(
             step_input,
             find_deploy_set(
+                logger=self._logger,
                 repo_config=RepoConfig.from_config(run_properties.config),
                 tag=step_input.run_properties.versioning.tag,
             ),

--- a/tests/stages/test_discovery.py
+++ b/tests/stages/test_discovery.py
@@ -3,11 +3,13 @@ from pathlib import Path
 
 from ruamel.yaml import YAML  # type: ignore
 
+from mpyl.project import load_project
 from src.mpyl.constants import BUILD_ARTIFACTS_FOLDER
 from src.mpyl.projects.find import load_projects
 from src.mpyl.stages.discovery import (
     find_invalidated_projects_for_stage,
     output_invalidated,
+    is_invalidated,
 )
 from src.mpyl.steps import Output
 from src.mpyl.steps import build, test, deploy
@@ -74,6 +76,17 @@ class TestDiscovery:
             [Revision(0, "hash", {"projects/job/file.py", "some_file.txt"})],
         )
         assert 1 == len(invalidated)
+
+    def test_should_correctly_check_root_path(self):
+        res = is_invalidated(
+            self.logger,
+            project=load_project(
+                root_test_path, Path("projects/sbt-service/deployment/project.yml")
+            ),
+            stage="build",
+            path="projects/sbt-service-other/file.py",
+        )
+        assert not res
 
     def test_invalidation_logic(self):
         test_output = Path(

--- a/tests/stages/test_discovery.py
+++ b/tests/stages/test_discovery.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from ruamel.yaml import YAML  # type: ignore
 
-from mpyl.project import load_project
+from src.mpyl.project import load_project
 from src.mpyl.constants import BUILD_ARTIFACTS_FOLDER
 from src.mpyl.projects.find import load_projects
 from src.mpyl.stages.discovery import (

--- a/tests/stages/test_discovery.py
+++ b/tests/stages/test_discovery.py
@@ -78,7 +78,7 @@ class TestDiscovery:
         assert 1 == len(invalidated)
 
     def test_should_correctly_check_root_path(self):
-        res = is_invalidated(
+        assert not is_invalidated(
             self.logger,
             project=load_project(
                 root_test_path, Path("projects/sbt-service/deployment/project.yml")
@@ -86,7 +86,6 @@ class TestDiscovery:
             stage="build",
             path="projects/sbt-service-other/file.py",
         )
-        assert not res
 
     def test_invalidation_logic(self):
         test_output = Path(

--- a/tests/stages/test_discovery.py
+++ b/tests/stages/test_discovery.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from ruamel.yaml import YAML  # type: ignore
@@ -19,6 +20,8 @@ yaml = YAML()
 
 
 class TestDiscovery:
+    logger = logging.getLogger(__name__)
+
     def test_should_find_invalidated_test_dependencies(self):
         with test_data.get_repo() as repo:
             touched_files = {"tests/projects/service/file.py", "tests/some_file.txt"}
@@ -26,6 +29,7 @@ class TestDiscovery:
             assert (
                 len(
                     find_invalidated_projects_for_stage(
+                        self.logger,
                         projects,
                         build.STAGE_NAME,
                         [Revision(0, "revision", touched_files)],
@@ -36,6 +40,7 @@ class TestDiscovery:
             assert (
                 len(
                     find_invalidated_projects_for_stage(
+                        self.logger,
                         projects,
                         test.STAGE_NAME,
                         [Revision(0, "revision", touched_files)],
@@ -46,6 +51,7 @@ class TestDiscovery:
             assert (
                 len(
                     find_invalidated_projects_for_stage(
+                        self.logger,
                         projects,
                         deploy.STAGE_NAME,
                         [Revision(0, "revision", touched_files)],
@@ -62,6 +68,7 @@ class TestDiscovery:
         ]
         projects = set(load_projects(root_test_path, project_paths))
         invalidated = find_invalidated_projects_for_stage(
+            self.logger,
             projects,
             TestStage.build().name,
             [Revision(0, "hash", {"projects/job/file.py", "some_file.txt"})],
@@ -96,13 +103,22 @@ class TestDiscovery:
             projects = load_projects(repo.root_dir, repo.find_projects())
             assert len(projects) == 13
             projects_for_build = find_invalidated_projects_for_stage(
-                projects, build.STAGE_NAME, [Revision(0, "revision", touched_files)]
+                self.logger,
+                projects,
+                build.STAGE_NAME,
+                [Revision(0, "revision", touched_files)],
             )
             projects_for_test = find_invalidated_projects_for_stage(
-                projects, test.STAGE_NAME, [Revision(0, "revision", touched_files)]
+                self.logger,
+                projects,
+                test.STAGE_NAME,
+                [Revision(0, "revision", touched_files)],
             )
             projects_for_deploy = find_invalidated_projects_for_stage(
-                projects, deploy.STAGE_NAME, [Revision(0, "revision", touched_files)]
+                self.logger,
+                projects,
+                deploy.STAGE_NAME,
+                [Revision(0, "revision", touched_files)],
             )
             assert len(projects_for_build) == 1
             assert len(projects_for_test) == 1


### PR DESCRIPTION
- Add debug logs when doing `mpyl build --verbose status`
- Fix a bug with project path startswith

----
### 📕 [TECH-702](https://vandebron.atlassian.net/browse/TECH-702) Verbose build status <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-321/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-321.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-321.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-321.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-702]: https://vandebron.atlassian.net/browse/TECH-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ