### PR TITLE
set default resources for all dagster repos

### DIFF
--- a/releases/notes/1.4.11.md
+++ b/releases/notes/1.4.11.md
@@ -1,0 +1,2 @@
+#### Enhancements
+- Set resources for Dagster user code servers (hardcoded)

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -47,6 +47,7 @@ def to_user_code_values(
                 "includeConfigInLaunchedRuns": {"enabled": True},
                 "name": f"{project.name}{name_suffix}",
                 "port": 3030,
+                "resources": {"requests": {"memory": "256Mi", "cpu": "50m"}, "limits":  {"memory": "512Mi", "cpu": "1000m"}}
             },
         ],
     }

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -47,7 +47,10 @@ def to_user_code_values(
                 "includeConfigInLaunchedRuns": {"enabled": True},
                 "name": f"{project.name}{name_suffix}",
                 "port": 3030,
-                "resources": {"requests": {"memory": "256Mi", "cpu": "50m"}, "limits":  {"memory": "512Mi", "cpu": "1000m"}}
+                "resources": {
+                    "requests": {"memory": "256Mi", "cpu": "50m"},
+                    "limits": {"memory": "512Mi", "cpu": "1000m"},
+                },
             },
         ],
     }

--- a/src/mpyl/utilities/helm/__init__.py
+++ b/src/mpyl/utilities/helm/__init__.py
@@ -2,8 +2,8 @@
 Helper methods for helm deployments
 """
 
-from mpyl.project import Target
-from mpyl.steps.models import RunProperties
+from ...project import Target
+from ...steps.models import RunProperties
 
 
 def convert_to_helm_release_name(name: str, tag: str) -> str:

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
@@ -21,3 +21,10 @@ deployments:
     enabled: true
   name: example-dagster-user-code-pr-1234
   port: 3030
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 50m
+    limits:
+      memory: 512Mi
+      cpu: 1000m

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_target_prod.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_target_prod.yaml
@@ -21,3 +21,10 @@ deployments:
     enabled: true
   name: example-dagster-user-code
   port: 3030
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 50m
+    limits:
+      memory: 512Mi
+      cpu: 1000m

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
@@ -19,3 +19,10 @@ deployments:
     enabled: true
   name: example-dagster-user-code-pr-1234
   port: 3030
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 50m
+    limits:
+      memory: 512Mi
+      cpu: 1000m


### PR DESCRIPTION
See here how resources of user code deployments should be set: https://github.com/dagster-io/dagster/blob/master/helm/dagster/charts/dagster-user-deployments/values.yaml#L114

This PR attempts to implement this. 

Check any pod starting with `udc` in grafana (e.g. [this one](https://grafana.prod-backend.vdbinfra.nl/k8s/clusters/c-r8bj6/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=Prometheus&var-cluster=&var-namespace=dagster&var-pod=ucd-pc-production-correction-848fd5c799-vtl7x)) and conclude with me that the resources I set are sensible.

----
### 📕 [DATA-1159](https://vandebron.atlassian.net/browse/DATA-1159) As a developer I don't want to waste money by overcommitting my app its resource requests in Kubernetes <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/557058:2bd83e5b-2844-4e1d-b8e6-1a34fa038742/c3c7ca86-9119-4b02-85ae-07b943b3cd2b/24" width="24" height="24" alt="pietercusters@vandebron.nl" /> 
– This ticket is a reminder for Pieter to follow-up with Pim on resources – 



**Story**
Every app we make in-house will be deployed to Kubernetes. Kubernetes uses so called resources requests (and limits) to make sure you app gets the resources it needs, but doesn't use too much and breaks other apps or the underlaying nodes.These are manual configurations, which can be found in the `project.yaml` and must be refined **before* deployment to production *and** each time you modify the [app.To](http://app.To)  use them correctly, please read/watch on of the articles below. In short:

** Kubernetes defines *Limits** as the maximum amount of a resource to be used by a container. This means that the container can never consume more than the memory amount or CPU amount indicated. It will either be throttled (CPU) or killed OOM (RAM) after hitting the limits.
** *Requests**, on the other hand, are the minimum guaranteed amount of a resource that is reserved for a container. CPU or RAM requested by one pod, can't be requested/used by another.

For this item we will focus on the **CPU* *requests**, not the memory requests and cpu/memory limits. Why?
Because we reserve 75% CPU while we're mostly only using 10%. See image below. This is expensive, but also makes it impossible to deploy sometimes, because the cluster seems "full".



**How?**
For each of the apps/deployments (not jobs, for now) your team is responsible for, verify it's actual CPU use here: [GRAFANA PROD](https://grafana.prod-backend.vdbinfra.nl/k8s/clusters/c-r8bj6/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=Prometheus&var-cluster=&var-namespace=batterypack&var-pod=batterypackapi-5587ddddf7-4cc2t&from=now-2d&to=now).
You can filter on namespace and app name. In the `CPU Usage` graph you can see the "normal" CPU usage of the app. Don't look at the spikes, just try to find the trend of normal usage.
In the URL I added as an example to GRAFANA PROD above, you can see that the app:

- is using around **0.033** CPU
- requested **0.4** CPU
- limits the CPU at 2 full CPU's

The preferred modification here should be reducing the CPU requests rom 0.4 to +/- 0.05. We'll keep the limits untouched for now. Redeploy.
Please have a quick look if the CPU requests could be lower in `acce}} and {{test}} in comparison to {{prod`. Those clusters are smaller and the apps are being used less, usually!**Resources**

* Watch Kubernetes Resource Requests explained in 5m: [watch?v=*nknHwTKlh8](https://www.youtube.com/watch?v=*nknHwTKlh8) 
* Read (until Namespace settings): [kubernetes-best-practices-resource-requests-and-limits](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-resource-requests-and-limits) 
* Grafana dashboards to determine CPU usage: [acce|https://grafana.acce-backend.vdbinfra.nl/k8s/clusters/c-6mkzg/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=Prometheus&var-cluster=&var-namespace=batterypack&var-pod=batterypackapi-5686477f9d-lqmfl&from=now-2d&to=now], [test|https://grafana.test-backend.vdbinfra.nl/k8s/clusters/c-z8wzm/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=Prometheus&var-cluster=&var-namespace=batterypack&var-pod=batterypackapi-5b76b64bb5-f85vk&from=now-2d&to=now], [prod](https://grafana.prod-backend.vdbinfra.nl/k8s/clusters/c-r8bj6/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&var-datasource=Prometheus&var-cluster=&var-namespace=batterypack&var-pod=batterypackapi-5587ddddf7-4cc2t&from=1698545466881&to=1698556326021)
* `project.yaml` example: [https://github.com/Vandebron/Vandebron/blob/master/apps/customer-dashboard/deployment/project.yml#L33](https://github.com/Vandebron/Vandebron/blob/master/apps/customer-dashboard/deployment/project.yml#L33)

🏗️ Build [3](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-324/3/display/redirect) ✅ Successful, started by _Pieter Custers_  
🚀 *[cloudfront-service](https://cloudfront-service-324.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-324.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-324.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[DATA-1159]: https://vandebron.atlassian.net/browse/DATA-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ