### PR TITLE
[TECH-713] Take tag into account for artifacts and build status cli commands

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -489,7 +489,8 @@ def pull(obj: CliContext, tag: str, pr: int, path: Path):
     run_properties = initiate_run_properties(
         config=obj.config,
         properties=obj.run_properties,
-        cli_parameters=MpylCliParameters(tag=tag),
+        run_plan={},
+        all_projects=set(),
     )
     target_branch = __get_target_branch(run_properties, tag, pr)
 
@@ -520,7 +521,8 @@ def push(obj: CliContext, tag: str, pr: int, path: Path, artifact_type: str):
     run_properties = initiate_run_properties(
         config=obj.config,
         properties=obj.run_properties,
-        cli_parameters=MpylCliParameters(tag=tag),
+        run_plan={},
+        all_projects=set(),
     )
     target_branch = __get_target_branch(run_properties, tag, pr)
 

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -231,9 +231,7 @@ def status(obj: CliContext, all_, projects):
     try:
         upgrade_check = asyncio.wait_for(warn_if_update(obj.console), timeout=3)
         parameters = MpylCliParameters(
-            local=sys.stdout.isatty(),
-            all=all_,
-            projects=projects,
+            local=sys.stdout.isatty(), all=all_, projects=projects
         )
         print_status(obj, parameters)
     except asyncio.exceptions.TimeoutError:
@@ -489,7 +487,9 @@ def artifacts():
 @click.pass_obj
 def pull(obj: CliContext, tag: str, pr: int, path: Path):
     run_properties = initiate_run_properties(
-        config=obj.config, properties=obj.run_properties
+        config=obj.config,
+        properties=obj.run_properties,
+        cli_parameters=MpylCliParameters(tag=tag),
     )
     target_branch = __get_target_branch(run_properties, tag, pr)
 
@@ -518,7 +518,9 @@ def pull(obj: CliContext, tag: str, pr: int, path: Path):
 @click.pass_obj
 def push(obj: CliContext, tag: str, pr: int, path: Path, artifact_type: str):
     run_properties = initiate_run_properties(
-        config=obj.config, properties=obj.run_properties
+        config=obj.config,
+        properties=obj.run_properties,
+        cli_parameters=MpylCliParameters(tag=tag),
     )
     target_branch = __get_target_branch(run_properties, tag, pr)
 

--- a/src/mpyl/steps/run_properties.py
+++ b/src/mpyl/steps/run_properties.py
@@ -45,6 +45,7 @@ def initiate_run_properties(
                     changes_in_branch=(
                         repo.changes_in_branch_including_local()
                         if cli_parameters.local
+                        or properties["build"]["versioning"].get("tag")
                         else (
                             repo.changes_in_tagged_commit(cli_parameters.tag)
                             if cli_parameters.tag

--- a/src/mpyl/steps/run_properties.py
+++ b/src/mpyl/steps/run_properties.py
@@ -17,6 +17,7 @@ def initiate_run_properties(
     run_plan: Optional[dict[Stage, set[Project]]] = None,
     all_projects: Optional[set[Project]] = None,
 ) -> RunProperties:
+    tag = cli_parameters.tag or properties["build"]["versioning"].get("tag")
     if all_projects is None or run_plan is None:
         with Repository(RepoConfig.from_config(config)) as repo:
             if all_projects is None:
@@ -46,9 +47,8 @@ def initiate_run_properties(
                         repo.changes_in_branch_including_local()
                         if cli_parameters.local
                         else (
-                            repo.changes_in_tagged_commit(cli_parameters.tag)
-                            if cli_parameters.tag
-                            or properties["build"]["versioning"].get("tag")
+                            repo.changes_in_tagged_commit(tag)
+                            if tag
                             else repo.changes_in_branch()
                         )
                     ),
@@ -64,7 +64,7 @@ def initiate_run_properties(
             run_plan=run_plan,
             revision=repo.get_sha,
             branch=repo.get_branch,
-            tag=cli_parameters.tag,
+            tag=tag,
             stages=stages,
             all_projects=all_projects,
         )
@@ -74,5 +74,5 @@ def initiate_run_properties(
         config=config,
         run_plan=run_plan,
         all_projects=all_projects,
-        cli_tag=cli_parameters.tag,
+        cli_tag=tag,
     )

--- a/src/mpyl/steps/run_properties.py
+++ b/src/mpyl/steps/run_properties.py
@@ -45,10 +45,10 @@ def initiate_run_properties(
                     changes_in_branch=(
                         repo.changes_in_branch_including_local()
                         if cli_parameters.local
-                        or properties["build"]["versioning"].get("tag")
                         else (
                             repo.changes_in_tagged_commit(cli_parameters.tag)
                             if cli_parameters.tag
+                            or properties["build"]["versioning"].get("tag")
                             else repo.changes_in_branch()
                         )
                     ),


### PR DESCRIPTION
branch: featute/TECH-713-fix-tag-builds

----
### 📕 [TECH-713](https://vandebron.atlassian.net/browse/TECH-713) Fix namespace interpolation when doing manual selection <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 


🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-326/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-326.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-326.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-326.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-713]: https://vandebron.atlassian.net/browse/TECH-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ