### PR TITLE
[TECH-722] Check if folder exists before trying to read the test suites

### DIFF
--- a/src/mpyl/utilities/junit/__init__.py
+++ b/src/mpyl/utilities/junit/__init__.py
@@ -39,7 +39,9 @@ def to_test_suites(artifact: JunitTestSpec) -> list[TestSuite]:
 
     xml = JUnitXml()
     for file_name in [
-        fn for fn in os.listdir(junit_result_path) if fn.endswith(".xml")
+        fn
+        for fn in os.listdir(junit_result_path)
+        if os.path.isdir(junit_result_path) and fn.endswith(".xml")
     ]:
         xml += JUnitXml.fromfile(Path(junit_result_path, file_name).as_posix())
 


### PR DESCRIPTION
branch: feature/TECH-722-check-for-dir

----
### 📕 [TECH-722](https://vandebron.atlassian.net/browse/TECH-722) Do not fail if test results are not produced <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Sbt test step fails if test results our not in a predefined folder:

```
                        fn for fn in os.listdir(junit*result*path) if fn.endswith(".xml")                                                                                                               
                    FileNotFoundError: [Errno 2] No such file or directory: 'server/integration-tests/target/test-reports'                                                                              
❗ Failed with exception                                                                                                                                                                                
For Sbt Test on integrationTests at stage test   
```

[https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL Pipeline/job/PR-12566/14/console](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline/job/PR-12566/14/console)

It should probably log a warning but not make the whole thing fail

----

on the other hand, when the sbt command fails, the step should not be a file not found error, but a more descriptive one. e.g.: [https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL Pipeline/view/change-requests/job/PR-12272/lastBuild/console](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline/view/change-requests/job/PR-12272/lastBuild/console)



🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-334/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-334.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-334.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-334.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-722]: https://vandebron.atlassian.net/browse/TECH-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ