### PR TITLE
Feature/tech 701 parallel improvements

### DIFF
--- a/releases/notes/1.4.12.md
+++ b/releases/notes/1.4.12.md
@@ -3,3 +3,4 @@
 
 #### Bug Fixes
 - Fix `mpyl build clean` command for override projects
+- Fix test results collection on compile errors for sbt test

--- a/releases/notes/1.4.12.md
+++ b/releases/notes/1.4.12.md
@@ -1,6 +1,8 @@
 #### Enhancements
 - Several small code improvements
+- Improve sbt test step
 
 #### Bug Fixes
 - Fix `mpyl build clean` command for override projects
 - Fix test results collection on compile errors for sbt test
+- Make sure sbt test coverage always gets turned off again

--- a/releases/notes/1.4.12.md
+++ b/releases/notes/1.4.12.md
@@ -1,0 +1,5 @@
+#### Enhancements
+- Several small code improvements
+
+#### Bug Fixes
+- Fix `mpyl build clean` command for override projects

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -163,7 +163,7 @@ def run_build(
                     logging.warning(f"Deployment failed for {proj.name}")
                     return accumulator
 
-            if accumulator.failed_result:
+            if accumulator.failed_results:
                 logging.warning(f"One of the builds failed at Stage {stage.name}")
                 return accumulator
         return accumulator

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -473,7 +473,7 @@ def clean(obj: CliContext, filter_):
 
     paths_to_clean = [path for path in found_projects if path.exists()]
     if paths_to_clean:
-        for target_path in paths_to_clean:
+        for target_path in set(paths_to_clean):
             shutil.rmtree(target_path)
             obj.console.print(f"🧹 Cleaned up {target_path}")
     else:

--- a/src/mpyl/reporting/formatting/markdown.py
+++ b/src/mpyl/reporting/formatting/markdown.py
@@ -102,10 +102,16 @@ def execution_plan_as_markdown(run_result: RunResult):
     if exception:
         result += f"For _{exception.executor}_ on _{exception.project_name}_ at stage _{exception.stage}_ \n"
         result += f"\n\n{exception}\n\n"
-    elif run_result.failed_result:
-        failed = run_result.failed_result
-        result += f"For _{failed.project.name}_ at stage _{failed.stage.name}_ \n"
-        result += f"\n\n{run_result.failed_result.output.message}\n\n"
+    elif run_result.failed_results:
+        failed_projects = ", ".join(
+            set(failed.project.name for failed in run_result.failed_results)
+        )
+        failed_stage = next(failed.stage.name for failed in run_result.failed_results)
+        failed_outputs = ". \n\n".join(
+            [failed.output.message for failed in run_result.failed_results]
+        )
+        result += f"For _{failed_projects}_ at stage _{failed_stage}_ \n"
+        result += f"\n\n{failed_outputs}\n\n"
     for stage in run_result.run_properties.stages:
         result += markdown_for_stage(run_result, stage)
     return result

--- a/src/mpyl/steps/build/sbt.py
+++ b/src/mpyl/steps/build/sbt.py
@@ -40,7 +40,9 @@ class BuildSbt(Step):
         image_name = docker_image_tag(step_input)
         command = self._construct_sbt_command(step_input, image_name)
 
-        output = custom_check_output(self.logger, command=command)
+        output = custom_check_output(
+            logger=self.logger, command=command, use_print=True
+        )
         artifact = input_to_artifact(
             ArtifactType.DOCKER_IMAGE, step_input, DockerImageSpec(image=image_name)
         )

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -1,7 +1,5 @@
 """ Step that runs relevant cypress tests in the post deploy stage """
-import itertools
 import os
-from concurrent.futures import ProcessPoolExecutor, Future
 from logging import Logger
 
 from kubernetes.config.kube_config import KubeConfigMerger
@@ -14,6 +12,7 @@ from ...project import Target
 from ...utilities.cypress import CypressConfig
 from ...utilities.docker import execute_with_stream
 from ...utilities.junit import JunitTestSpec
+from ...utilities.parallel import run_in_parallel, ParallelCommand
 
 
 class CypressTest(Step):
@@ -62,37 +61,32 @@ class CypressTest(Step):
                 docker_container, step_input, reports_folder
             )
             record_key = cypress_config.record_key
-            run_command = ""
 
             if record_key:
                 ci_build_id = f"{cypress_config.ci_build_id}-{step_input.project.name}"
-                machines = [1, 2, 3, 4]
-                threads: list[Future] = []
-
-                for machine in machines:
-                    run_command = (
-                        f'bash -c "Xvfb :10{machine} & XDG_CONFIG_HOME=/tmp/cyhome{machine} '
-                        f"DISPLAY=:10{machine}  yarn cypress run --spec '{specs_string}' --ci-build-id "
-                        f"{ci_build_id} --parallel --reporter-options "
-                        f'"mochaFile={reports_folder}/[hash].xml" --record --key '
-                        'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                run_command = (
+                    f'bash -c "Xvfb :10$MACHINE & XDG_CONFIG_HOME=/tmp/cyhome$MACHINE '
+                    f"DISPLAY=:10$MACHINE  yarn cypress run --spec '{specs_string}' --ci-build-id "
+                    f"{ci_build_id} --parallel --reporter-options "
+                    f'"mochaFile={reports_folder}/[hash].xml" --record --key '
+                    'b6a2aab1-0b80-4ca0-a56c-1c8d98a8189c || true "'
+                )
+                machines = ["1", "2", "3", "4"]
+                commands = [
+                    ParallelCommand(
+                        function=execute_with_stream,
+                        parameters={
+                            "logger": self._logger,
+                            "container": docker_container,
+                            "command": run_command.replace("$MACHINE", machine),
+                            "task_name": "Running cypress tests parallel",
+                        },
                     )
-                    executor = ProcessPoolExecutor(max_workers=len(machines))
-                    threads.append(
-                        executor.submit(
-                            execute_with_stream,
-                            logger=self._logger,
-                            container=docker_container,
-                            command=run_command,
-                            task_name="Running cypress tests parallel",
-                            multiprocess=True,
-                        )
-                    )
-
-                result: list[str] = list(
-                    itertools.chain.from_iterable(
-                        [thread.result() for thread in threads]
-                    )
+                    for machine in machines
+                ]
+                result: list[str] = run_in_parallel(
+                    commands=commands,
+                    number_of_threads=len(machines),
                 )
             else:
                 run_command = (

--- a/src/mpyl/steps/run.py
+++ b/src/mpyl/steps/run.py
@@ -36,8 +36,10 @@ class RunResult:
         return "❌ Failed"
 
     @property
-    def failed_result(self) -> Optional[StepResult]:
-        return next((r for r in self._results if not r.output.success), None)
+    def failed_results(self) -> Optional[list[StepResult]]:
+        failed_results = list((r for r in self._results if not r.output.success))
+
+        return failed_results if len(failed_results) > 0 else None
 
     @property
     def progress_fraction(self) -> float:

--- a/src/mpyl/steps/steps.py
+++ b/src/mpyl/steps/steps.py
@@ -43,6 +43,7 @@ class Steps:
 
     _logger: Logger
     _properties: RunProperties
+    _steps_collection: StepsCollection
 
     def __init__(
         self,

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -100,9 +100,10 @@ class TestSbt(Step):
             suite = to_test_suites(
                 cast(JunitTestSpec, test_result.produced_artifact.spec)
             )
-            errors = sum_suites(suite).errors
+            combined = sum_suites(suite)
+            errors = combined.errors
             summary = dataclasses.replace(
-                sum_suites(suite), errors=errors if test_result.success else errors + 1
+                combined, errors=errors if test_result.success else errors + 1
             )
             return Output(
                 success=summary.is_success,

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -1,4 +1,5 @@
 """A step to compile and run tests for an SBT project"""
+import dataclasses
 from logging import Logger
 from typing import Callable, cast
 
@@ -93,7 +94,10 @@ class TestSbt(Step):
             suite = to_test_suites(
                 cast(JunitTestSpec, test_result.produced_artifact.spec)
             )
-            summary = sum_suites(suite)
+            errors = sum_suites(suite).errors
+            summary = dataclasses.replace(
+                sum_suites(suite), errors=errors if test_result.success else errors + 1
+            )
             return Output(
                 success=summary.is_success,
                 message=f"Tests results produced for {project.name} ({summary})",

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -41,7 +41,9 @@ class TestSbt(Step):
         command_compile = self._construct_sbt_command(
             step_input, sbt_config, self._construct_sbt_command_compile_with_coverage
         )
-        compile_outcome = custom_check_output(self._logger, command_compile)
+        compile_outcome = custom_check_output(
+            logger=self._logger, command=command_compile, use_print=True
+        )
         project_name = step_input.project.name
         if not compile_outcome.success:
             return Output(
@@ -53,7 +55,9 @@ class TestSbt(Step):
         command_test = self._construct_sbt_command(
             step_input, sbt_config, self._construct_sbt_command_test_with_coverage
         )
-        test_outcome = custom_check_output(self._logger, command_test)
+        test_outcome = custom_check_output(
+            logger=self._logger, command=command_test, use_print=True
+        )
         artifact = self._extract_test_report(step_input.project, step_input)
         if not test_outcome.success:
             return Output(
@@ -69,7 +73,9 @@ class TestSbt(Step):
         command_test_without_coverage = self._construct_sbt_command(
             step_input, sbt_config, self._construct_sbt_command_test_without_coverage
         )
-        run_outcome = custom_check_output(self._logger, command_test_without_coverage)
+        run_outcome = custom_check_output(
+            logger=self._logger, command=command_test_without_coverage, use_print=True
+        )
         artifact = self._extract_test_report(step_input.project, step_input)
         if not run_outcome.success:
             return Output(

--- a/src/mpyl/steps/test/sbt.py
+++ b/src/mpyl/steps/test/sbt.py
@@ -1,7 +1,6 @@
 """A step to compile and run tests for an SBT project"""
-import dataclasses
 from logging import Logger
-from typing import Callable, cast
+from typing import cast
 
 from . import STAGE_NAME
 from .after_test import IntegrationTestAfter
@@ -37,44 +36,32 @@ class TestSbt(Step):
             after=IntegrationTestAfter(logger),
         )
 
-    def _test_with_coverage(self, step_input: Input, sbt_config: SbtConfig) -> Output:
+    def _test(self, step_input: Input, sbt_config: SbtConfig) -> Output:
         command_compile = self._construct_sbt_command(
-            step_input, sbt_config, self._construct_sbt_command_compile_with_coverage
+            project_name=step_input.project.name, config=sbt_config, compile_test=True
         )
         compile_outcome = custom_check_output(
             logger=self._logger, command=command_compile, use_print=True
         )
-        project_name = step_input.project.name
         if not compile_outcome.success:
+            if sbt_config.test_with_coverage:
+                coverage_off_command = sbt_config.to_command(
+                    sbt_config.test_with_client, ["coverageOff"]
+                )
+                custom_check_output(
+                    logger=self._logger, command=coverage_off_command, use_print=True
+                )
             return Output(
                 success=False,
-                message=f"Tests failed to compile for {project_name}",
+                message=f"Tests failed to compile for {step_input.project.name}",
                 produced_artifact=None,
             )
 
         command_test = self._construct_sbt_command(
-            step_input, sbt_config, self._construct_sbt_command_test_with_coverage
-        )
-        test_outcome = custom_check_output(
-            logger=self._logger, command=command_test, use_print=True
-        )
-        artifact = self._extract_test_report(step_input.project, step_input)
-        if not test_outcome.success:
-            return Output(
-                success=False,
-                message=f"Tests failed to run for {project_name}. No test results have been recorded.",
-                produced_artifact=artifact,
-            )
-        return Output(success=True, message="Success", produced_artifact=artifact)
-
-    def _test_without_coverage(
-        self, step_input: Input, sbt_config: SbtConfig
-    ) -> Output:
-        command_test_without_coverage = self._construct_sbt_command(
-            step_input, sbt_config, self._construct_sbt_command_test_without_coverage
+            project_name=step_input.project.name, config=sbt_config, compile_test=False
         )
         run_outcome = custom_check_output(
-            logger=self._logger, command=command_test_without_coverage, use_print=True
+            logger=self._logger, command=command_test, use_print=True
         )
         artifact = self._extract_test_report(step_input.project, step_input)
         if not run_outcome.success:
@@ -89,22 +76,13 @@ class TestSbt(Step):
         project = step_input.project
         sbt_config = SbtConfig.from_config(config=step_input.run_properties.config)
         self._logger.debug(f"Config {sbt_config}")
-
-        test_result = (
-            self._test_with_coverage(step_input, sbt_config)
-            if sbt_config.test_with_coverage
-            else self._test_without_coverage(step_input, sbt_config)
-        )
+        test_result = self._test(step_input=step_input, sbt_config=sbt_config)
 
         if test_result.produced_artifact:
             suite = to_test_suites(
                 cast(JunitTestSpec, test_result.produced_artifact.spec)
             )
-            combined = sum_suites(suite)
-            errors = combined.errors
-            summary = dataclasses.replace(
-                combined, errors=errors if test_result.success else errors + 1
-            )
+            summary = sum_suites(suite)
             return Output(
                 success=summary.is_success,
                 message=f"Tests results produced for {project.name} ({summary})",
@@ -114,22 +92,21 @@ class TestSbt(Step):
         return test_result
 
     @staticmethod
-    def _construct_sbt_command_compile_with_coverage(step_input: Input) -> list[str]:
-        return [f"project {step_input.project.name}", "coverageOn", "test:compile"]
-
-    @staticmethod
-    def _construct_sbt_command_test_with_coverage(step_input: Input):
-        return [f"project {step_input.project.name}", "test", "coverageOff"]
-
-    @staticmethod
-    def _construct_sbt_command_test_without_coverage(step_input: Input):
-        return [f"{step_input.project.name}/test"]
-
-    @staticmethod
     def _construct_sbt_command(
-        step_input: Input, config: SbtConfig, commands_fn: Callable[[Input], list[str]]
+        project_name: str, config: SbtConfig, compile_test: bool
     ):
-        return config.to_command(config.test_with_client, commands_fn(step_input))
+        command = list(
+            filter(
+                None,
+                [
+                    f"project {project_name}",
+                    "coverageOn" if config.test_with_coverage else None,
+                    f"test{':compile' if compile_test else ''}",
+                    "coverageOff" if config.test_with_coverage else None,
+                ],
+            )
+        )
+        return config.to_command(config.test_with_client, command)
 
     @staticmethod
     def _extract_test_report(project: Project, step_input: Input) -> Artifact:

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -109,23 +109,13 @@ class DockerConfig:
 
 
 def execute_with_stream(
-    logger: Logger,
-    container: Container,
-    command: str,
-    task_name: str,
-    multiprocess: bool = False,
+    logger: Logger, container: Container, command: str, task_name: str
 ):
-    if multiprocess:  # Logger settings need to be re-applied in each process
-        logger.setLevel(logging.INFO)
-        logger.handlers.clear()
-
     result = cast(
         Iterator[tuple[str, bytes]],
         container.execute(command=shlex.split(command), stream=True),
     )
     result_list = stream_docker_logging(logger, result, task_name)
-
-    logger.handlers.clear()
 
     return result_list
 
@@ -170,11 +160,7 @@ def get_default_build_args(
 
 
 def docker_registry_path(docker_config: DockerRegistryConfig, image_name: str) -> str:
-    path_components = [
-        docker_config.host_name,
-        docker_config.organization,
-        image_name,
-    ]
+    path_components = [docker_config.host_name, docker_config.organization, image_name]
     return "/".join([c for c in path_components if c]).lower()
 
 

--- a/src/mpyl/utilities/junit/__init__.py
+++ b/src/mpyl/utilities/junit/__init__.py
@@ -38,11 +38,11 @@ def to_test_suites(artifact: JunitTestSpec) -> list[TestSuite]:
     junit_result_path = artifact.test_output_path
 
     xml = JUnitXml()
-    for file_name in [
-        fn
-        for fn in os.listdir(junit_result_path)
-        if os.path.isdir(junit_result_path) and fn.endswith(".xml")
-    ]:
+    for file_name in (
+        [fn for fn in os.listdir(junit_result_path) if fn.endswith(".xml")]
+        if os.path.isdir(junit_result_path)
+        else []
+    ):
         xml += JUnitXml.fromfile(Path(junit_result_path, file_name).as_posix())
 
     suites = [TestSuite.fromelem(s) for s in xml]

--- a/src/mpyl/utilities/parallel/__init__.py
+++ b/src/mpyl/utilities/parallel/__init__.py
@@ -1,0 +1,35 @@
+"""Utility for running commands in parallel"""
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Callable, Any, TypeVar, Iterable
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ParallelCommand:
+    function: Callable
+    parameters: dict[str, Any]
+
+
+def run_in_parallel(
+    commands: list[ParallelCommand],
+    number_of_threads: int,
+) -> list[T]:
+    threads: list[Future] = []
+    executor = ThreadPoolExecutor(max_workers=number_of_threads)
+    for command in commands:
+        threads.append(executor.submit(command.function, **command.parameters))
+
+    results: list[T] = list(__flatten([thread.result() for thread in threads]))
+
+    return results
+
+
+def __flatten(object_to_flatten: Any):
+    if isinstance(object_to_flatten, Iterable):
+        for i in object_to_flatten:
+            if isinstance(i, Iterable) and not isinstance(i, (str, bytes)):
+                yield from __flatten(i)
+            else:
+                yield i

--- a/src/mpyl/utilities/sbt/__init__.py
+++ b/src/mpyl/utilities/sbt/__init__.py
@@ -35,7 +35,7 @@ class SbtConfig:
         )
 
     def to_command(self, client_mode: bool, sbt_commands: list[str]):
-        cmd = [self.sbt_client_command if client_mode else self.sbt_command]
+        cmd = (self.sbt_client_command if client_mode else self.sbt_command).split(" ")
         if self.verbose:
             cmd.append("-v")
         cmd.extend([f"-J{opt}" for opt in self.java_opts.split(" ")])

--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -4,6 +4,7 @@ import subprocess
 from logging import Logger
 from typing import Union
 
+from ..logging import try_parse_ansi
 from ...steps.models import Output
 
 
@@ -21,6 +22,8 @@ def custom_check_output(
 
     command_argument = " ".join(command)
     logger.info(f"Executing: '{command_argument}'")
+    logger = logger.getChild("Subprocess")
+
     try:
         if capture_stdout:
             out = subprocess.check_output(command, stderr=subprocess.STDOUT).decode(
@@ -36,7 +39,7 @@ def custom_check_output(
 
             for line in iter(process.stdout.readline, ""):
                 if line:
-                    print(line.rstrip())
+                    logger.info(try_parse_ansi(line.rstrip()))
                 if process.poll() is not None:
                     break
             success = process.wait() == 0

--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -9,7 +9,10 @@ from ...steps.models import Output
 
 
 def custom_check_output(
-    logger: Logger, command: Union[str, list[str]], capture_stdout: bool = False
+    logger: Logger,
+    command: Union[str, list[str]],
+    capture_stdout: bool = False,
+    use_print: bool = False,
 ) -> Output:
     """
     Wrapper around subprocess.Popen
@@ -39,7 +42,12 @@ def custom_check_output(
 
             for line in iter(process.stdout.readline, ""):
                 if line:
-                    logger.info(try_parse_ansi(line.rstrip()))
+                    stripped_line = line.rstrip()
+                    if use_print:
+                        print(stripped_line)
+                    else:
+                        logger.info(try_parse_ansi(stripped_line))
+
                 if process.poll() is not None:
                     break
             success = process.wait() == 0

--- a/tests/steps/build_step/test/test_sbt_test.py
+++ b/tests/steps/build_step/test/test_sbt_test.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from src.mpyl.steps.models import Input
 from src.mpyl.steps.test.sbt import TestSbt
 from src.mpyl.utilities.sbt import SbtConfig
@@ -11,49 +13,56 @@ class TestBuildSbt:
 
     def test_sbt_test_compile_command_should_be_properly_constructed(self):
         command = TestSbt._construct_sbt_command(
-            self.step_input,
+            self.step_input.project.name,
             self.sbt_config,
-            TestSbt._construct_sbt_command_compile_with_coverage,
+            True,
         )
         assert " ".join(command) == (
             "sbt -v -J-Xmx4G -J-Xms4G -J-XX:+UseG1GC -J-XX:+CMSClassUnloadingEnabled "
             "-J-Xss2M -Duser.timezone=GMT -Djline.terminal=jline.UnixTerminal project "
-            "dockertest; coverageOn; test:compile"
+            "dockertest; coverageOn; test:compile; coverageOff"
         )
 
     def test_sbt_test_test_command_should_be_properly_constructed(self):
         command = TestSbt._construct_sbt_command(
-            self.step_input,
+            self.step_input.project.name,
             self.sbt_config,
-            TestSbt._construct_sbt_command_test_with_coverage,
+            False,
         )
         assert " ".join(command) == (
             "sbt -v -J-Xmx4G -J-Xms4G -J-XX:+UseG1GC -J-XX:+CMSClassUnloadingEnabled "
             "-J-Xss2M -Duser.timezone=GMT -Djline.terminal=jline.UnixTerminal project "
-            "dockertest; test; coverageOff"
+            "dockertest; coverageOn; test; coverageOff"
         )
 
-    def test_sbt_test_without_coverage_but_with_client_command_should_be_properly_constructed(
+    def test_sbt_test_compile_without_coverage_but_with_client_command_should_be_properly_constructed(
         self,
     ):
         sbt_config = self.sbt_config
-        sbt_config_with_coverage = SbtConfig(
-            sbt_config.java_opts,
-            sbt_config.sbt_opts,
-            sbt_command=sbt_config.sbt_command,
-            sbt_client_command=sbt_config.sbt_client_command,
-            test_with_coverage=False,
-            verbose=False,
-            build_with_client=True,
-            test_with_client=True,
+        sbt_config_with_coverage = dataclasses.replace(
+            sbt_config, test_with_coverage=False, test_with_client=True, verbose=False
         )
         command = TestSbt._construct_sbt_command(
-            self.step_input,
-            sbt_config_with_coverage,
-            TestSbt._construct_sbt_command_test_without_coverage,
+            self.step_input.project.name, sbt_config_with_coverage, True
         )
         assert " ".join(command) == (
             "sbtn -J-Xmx4G -J-Xms4G -J-XX:+UseG1GC -J-XX:+CMSClassUnloadingEnabled "
-            "-J-Xss2M -Duser.timezone=GMT -Djline.terminal=jline.UnixTerminal "
-            "dockertest/test"
+            "-J-Xss2M -Duser.timezone=GMT -Djline.terminal=jline.UnixTerminal project "
+            "dockertest; test:compile"
+        )
+
+    def test_sbt_test_test_without_coverage_but_with_client_command_should_be_properly_constructed(
+        self,
+    ):
+        sbt_config = self.sbt_config
+        sbt_config_with_coverage = dataclasses.replace(
+            sbt_config, test_with_coverage=False, test_with_client=True, verbose=False
+        )
+        command = TestSbt._construct_sbt_command(
+            self.step_input.project.name, sbt_config_with_coverage, False
+        )
+        assert " ".join(command) == (
+            "sbtn -J-Xmx4G -J-Xms4G -J-XX:+UseG1GC -J-XX:+CMSClassUnloadingEnabled "
+            "-J-Xss2M -Duser.timezone=GMT -Djline.terminal=jline.UnixTerminal project "
+            "dockertest; test"
         )

--- a/validate.py
+++ b/validate.py
@@ -7,11 +7,11 @@ from concurrent.futures import Future
 from dataclasses import dataclass
 
 from rich.console import RenderableType, Console
-from rich.errors import ConsoleError
 from rich.live import Live
 from rich.spinner import Spinner
 from rich.table import Table
-from rich.text import Text
+
+from src.mpyl.utilities.logging import try_parse_ansi
 
 COMMANDS = [
     "pipenv run format",
@@ -62,13 +62,6 @@ def trim(error_message: str) -> str:
         return "\n".join(lines).strip()
 
     return "\n".join(error_message.splitlines()[-10:])
-
-
-def try_parse_ansi(text: str):
-    try:
-        return Text.from_ansi(text)
-    except ConsoleError:
-        return Text(text)
 
 
 def to_row(job: Job) -> list[RenderableType]:


### PR DESCRIPTION


----
### 📕 [TECH-701](https://vandebron.atlassian.net/browse/TECH-701) Look into parallel stage steps <img src="https://secure.gravatar.com/avatar/4438c9af956adc9562fde9f029f624e2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJP-3.png" width="24" height="24" alt="jorgpost@vandebron.nl" /> 
Investigate if parallel runs are an option for the build and test stages. Maybe even configurable (like name & icon) from the run properties, i.e. set the amount of threads there.

There is example code in `src/mpyl/steps/postdeploy/cypress_test.py` which can maybe we extracted and re-used, keep in mind that code is for docker cmd’s though. Probably needs to be made a bit more abstract.

If this works, see how this affects build times. Start with only 2 threads and ramp up until performance gets worse because of resource limits in Jenkins / Platform. 



🏗️ Build [8](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-337/8/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-337.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-337.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-337.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-701]: https://vandebron.atlassian.net/browse/TECH-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ