### PR TITLE
[TECH-506] Ship typed file with mpyl

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-global-include *.schema.yml releases.txt
+global-include *.schema.yml releases.txt *.typed

--- a/releases/notes/1.4.13.md
+++ b/releases/notes/1.4.13.md
@@ -1,0 +1,2 @@
+#### Ship typing information
+- MPyL can now be type checked via `mypy`.

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,5 @@ setup(
     include_package_data=True,
     packages=setuptools.find_packages(where="./src"),
     python_requires=">= 3.9",
+    package_data={"mpyl": ["py.typed"]},
 )

--- a/src/mpyl/reporting/targets/slack.py
+++ b/src/mpyl/reporting/targets/slack.py
@@ -109,7 +109,7 @@ class SlackReporter(Reporter):
             raise ValueError("slack config not set")
         self._client = WebClient(token=slack_config["botToken"])
         self._channel = channel
-        self._title = f"MPyL run for {versioning_identifier} on {target}"
+        self._title = f"MPyL run for {versioning_identifier} on {str(target)}"
         icons = slack_config["icons"]
         self._icons = SlackIcons(
             success=icons["success"],

--- a/src/mpyl/reporting/targets/slack.py
+++ b/src/mpyl/reporting/targets/slack.py
@@ -47,6 +47,7 @@ from slack_sdk.models.blocks import (
 
 from . import Reporter, ReportOutcome
 from ..formatting.markdown import run_result_to_markdown
+from ...project import Target
 from ...steps.models import RunProperties
 from ...steps.run import RunResult
 
@@ -100,7 +101,7 @@ class SlackReporter(Reporter):
         config: dict,
         channel: Optional[str],
         versioning_identifier: str,
-        target: str,
+        target: Target,
         message_identifier: Optional[MessageIdentifier] = None,
     ):
         slack_config = config.get("slack")

--- a/tests/reporting/targets/test_slack.py
+++ b/tests/reporting/targets/test_slack.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from src.mpyl.project import Target
 from src.mpyl.reporting.targets.slack import to_slack_markdown, SlackReporter
 from tests import root_test_path
 from tests.reporting import create_test_result_with_plan, append_results
@@ -33,7 +34,7 @@ class TestSlackReporter:
             },
             None,
             "MPyL test build",
-            "target",
+            Target.PULL_REQUEST,
         )
         slack.send_report(run_result)
         append_results(run_result)


### PR DESCRIPTION
branch: feature/TECH-506_ship_typing_info

----
### 📕 [TECH-506](https://vandebron.atlassian.net/browse/TECH-506) Ship typing information with mpyl library <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
See [180](https://github.com/Vandebron/mpyl/issues/180) 

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-341/2/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-341.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-341.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-341.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[TECH-506]: https://vandebron.atlassian.net/browse/TECH-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ