### PR TITLE
do not figure out changes when doing manual build

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -1,15 +1,16 @@
 # Developer instructions
 
-## ..run example pipeline
+## ..install mpyl for development
 
-1. Install dependencies
-    ```shell
-    pipenv install -d
-    ```
-2. Run the Dagit UI
-    ```shell
-    dagit --workspace ./workspace.yml 
-    ```
+1. Clone the mpyl repo
+ ```shell
+ gh repo clone Vandebron/mpyl
+ ```
+
+2. Install dependencies
+ ```shell
+ pipenv install -d
+ ```
 
 ## ..run tests and checks
 
@@ -21,7 +22,8 @@ pipenv run validate
 
 ## ..create a pull request build
 
-After every push, if all validation passes, a test release is pushed to https://test.pypi.org/project/mpyl/.
+After working on a branch in MPyL repo, you can open a PR.
+After every push, if all validations pass, a test release is pushed to https://test.pypi.org/project/mpyl/.
 The naming of the version follows a `<pr_number>.<build_number>` pattern.
 
 A pull request build can be used in `Pipfile` via

--- a/releases/notes/1.4.15.md
+++ b/releases/notes/1.4.15.md
@@ -3,3 +3,6 @@
 
 #### Enhancements
 - Adds the optional `hasSwagger` field to enhance PR descriptions. This update ensures accurate URL display for services that do not use Swagger
+
+#### Manual build improvements
+- Do not get changes from the remote repository when doing manual build

--- a/src/mpyl/steps/run_properties.py
+++ b/src/mpyl/steps/run_properties.py
@@ -51,7 +51,9 @@ def initiate_run_properties(
                             if tag
                             else repo.changes_in_branch()
                         )
-                    ),
+                    )
+                    if not cli_parameters.projects
+                    else [],
                     stages=stages,
                     build_all=cli_parameters.all,
                     selected_stage=cli_parameters.stage,

--- a/src/mpyl/steps/run_properties.py
+++ b/src/mpyl/steps/run_properties.py
@@ -52,7 +52,7 @@ def initiate_run_properties(
                             else repo.changes_in_branch()
                         )
                     )
-                    if not cli_parameters.projects
+                    if not cli_parameters.projects or cli_parameters.all
                     else [],
                     stages=stages,
                     build_all=cli_parameters.all,


### PR DESCRIPTION
- When constructing the run_properties, do not check the repo to figure out changes when we're doing a manual build or a build all

----
 # ⚠️ Could not find ticket corresponding to `feature/do_not_figure_out_changes_when_manual_build. Does your branch name follow the correct pattern?