### PR TITLE
[EA-186]: Add deploy target to Acceptance and Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,9 @@ dmypy.json
 .mpyl/
 Project_Default.xml
 
+#VSCode
+.vscode/
+
 #documentation
 docs/*
 !docs/schema
@@ -148,6 +151,9 @@ node_modules/
 #Scala
 .jvmopts
 .bsp/
+
+#Metals
+.metals/
 
 #Customized locally
 mpyl_config.yml

--- a/src/mpyl/schema/run_properties.schema.yml
+++ b/src/mpyl/schema/run_properties.schema.yml
@@ -61,7 +61,7 @@ properties:
           deploy_target:
             description: The deploy target.
             type: ["string", "null"]
-            enum: [ null,  'PullRequest', 'PullRequestBase', 'Acceptance', 'Production' ]
+            enum: [ null,  'PullRequest', 'PullRequestBase', 'Acceptance', 'Acceptance & PullRequestBase', 'Production' ]
       console:
         type: object
         additionalProperties: false


### PR DESCRIPTION
There is a requirement to add an Jenkins option to deploy to both acceptance and test. 

We need to add that option to `Deploy Target` enum in order to pass validation

Additionally added `VSCode` and `Metals` related `gitignore` exclusions 