### PR TITLE
Feature/ea 186 allow multiple deploy targets

### DIFF
--- a/releases/notes/1.5.0.md
+++ b/releases/notes/1.5.0.md
@@ -16,3 +16,16 @@ Include project overrides in list of projects.
 #### Multiple deploy targets
 
 Allow multiple deploy targets when using the jenkins cli command.
+
+
+#### Stage configuration
+
+MPyL can be configured to use an arbitrary set of build stages. Typical CI/CD stages are `build`, `test` or `deploy`.
+See `mpyl.steps` for the steps that come bundled and how to define and register your own.
+
+<details>
+  <summary>Example stage configuration</summary>
+```yaml
+.. include:: mpyl_stages.schema.yml
+```
+</details>

--- a/releases/notes/1.5.0.md
+++ b/releases/notes/1.5.0.md
@@ -11,4 +11,8 @@ Add support for an argocd repository and workflow:
 - The folder in the argocd repo structure has the following pattern: `k8s-manifests/{project_name}/{target}/{namespace}/*.yaml`.
 
 #### Manual selection
-- Include project overrides in list of projects
+Include project overrides in list of projects.
+
+#### Multiple deploy targets
+
+Allow multiple deploy targets when using the jenkins cli command.

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -402,7 +402,7 @@ def ask_for_tag_input(ctx, _param, value) -> Optional[str]:
     callback=ask_for_tag_input,
 )
 @click.pass_context
-def jenkins(  # pylint: disable=too-many-arguments
+def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
     ctx,
     user,
     password,

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -414,9 +414,8 @@ def jenkins(  # pylint: disable=too-many-arguments
     silent,
     tag,
 ):
-    upgrade_check = None
     try:
-        upgrade_check = asyncio.wait_for(warn_if_update(ctx.obj.console), timeout=5)
+        asyncio.run(warn_if_update(ctx.obj.console))
         if "jenkins" not in ctx.obj.config:
             ctx.obj.console.print(
                 "No Jenkins configuration found in config file. "
@@ -448,18 +447,10 @@ def jenkins(  # pylint: disable=too-many-arguments
                 tag=tag,
                 tag_target=getattr(Target, target) if tag else None,
             )
-
-            asyncio.wait_for(run_jenkins(run_argument), timeout=7200)
-            ctx.obj.console.print(f"after running jenkins for {target}...")
+            run_jenkins(run_argument)
+        # sys.exit()
     except asyncio.exceptions.TimeoutError:
-        ctx.obj.console.print("inside except block...")
         pass
-    finally:
-        ctx.obj.console.print("inside finally block...")
-        if upgrade_check:
-            asyncio.get_event_loop().run_until_complete(upgrade_check)
-
-    ctx.obj.console.print("end of function...")
 
 
 @build.command(help=f"Clean MPyL metadata in `{BUILD_ARTIFACTS_FOLDER}` folders")

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -431,7 +431,11 @@ def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
         if arguments:
             pipeline_parameters["BUILD_PARAMS"] = " ".join(arguments)
 
-        targets = select_targets()
+        targets = (
+            select_targets()
+            if tag
+            else [Target.PULL_REQUEST.name]  # pylint: disable=no-member
+        )
         for target in targets:
             run_argument = JenkinsRunParameters(
                 jenkins_user=user,

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -432,10 +432,7 @@ def jenkins(  # pylint: disable=too-many-arguments
             pipeline_parameters["BUILD_PARAMS"] = " ".join(arguments)
 
         targets = select_targets()
-        ctx.obj.console.print("targets: ", targets)
-
         for target in targets:
-            ctx.obj.console.print(f"running jenkins for {target}...")
             run_argument = JenkinsRunParameters(
                 jenkins_user=user,
                 jenkins_password=password,
@@ -448,7 +445,6 @@ def jenkins(  # pylint: disable=too-many-arguments
                 tag_target=getattr(Target, target) if tag else None,
             )
             run_jenkins(run_argument)
-        # sys.exit()
     except asyncio.exceptions.TimeoutError:
         pass
 

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -79,7 +79,7 @@ def __get_pr_pipeline(
         return None
 
 
-async def run_jenkins(run_config: JenkinsRunParameters):
+def run_jenkins(run_config: JenkinsRunParameters):
     log_console = Console(log_path=False, log_time=False)
     with log_console.status(
         "Fetching Github info.. [bright_blue]>gh pr view[/bright_blue]"
@@ -126,7 +126,7 @@ async def run_jenkins(run_config: JenkinsRunParameters):
                     follow=run_config.follow,
                     verbose=run_config.verbose,
                 )
-                await runner.run(run_config.pipeline_parameters)
+                runner.run(run_config.pipeline_parameters)
             except requests.ConnectionError:
                 play_sound(Sound.FAILURE)
                 status.console.log("⚠️ Could not connect. Are you on VPN?")

--- a/src/mpyl/cli/commands/build/jenkins.py
+++ b/src/mpyl/cli/commands/build/jenkins.py
@@ -79,7 +79,7 @@ def __get_pr_pipeline(
         return None
 
 
-def run_jenkins(run_config: JenkinsRunParameters):
+async def run_jenkins(run_config: JenkinsRunParameters):
     log_console = Console(log_path=False, log_time=False)
     with log_console.status(
         "Fetching Github info.. [bright_blue]>gh pr view[/bright_blue]"
@@ -126,7 +126,7 @@ def run_jenkins(run_config: JenkinsRunParameters):
                     follow=run_config.follow,
                     verbose=run_config.verbose,
                 )
-                runner.run(run_config.pipeline_parameters)
+                await runner.run(run_config.pipeline_parameters)
             except requests.ConnectionError:
                 play_sound(Sound.FAILURE)
                 status.console.log("⚠️ Could not connect. Are you on VPN?")

--- a/src/mpyl/utilities/jenkins/runner.py
+++ b/src/mpyl/utilities/jenkins/runner.py
@@ -137,9 +137,9 @@ class JenkinsRunner:
         self.status.console.log()
 
         play_sound(Sound.SUCCESS if finished_build.is_good() else Sound.FAILURE)
-        sys.exit()
 
-    def _stream_logs(self, build_to_follow, duration_estimation, verbose):
+    @staticmethod
+    def _stream_logs(build_to_follow, duration_estimation, verbose):
         progress = Progress(
             TimeElapsedColumn(),
             BarColumn(bar_width=None),


### PR DESCRIPTION


----

### 📕 [EA-186](https://vandebron.atlassian.net/browse/EA-186) [CI/CD] Add new option to deploy to test & acce together <img src="https://secure.gravatar.com/avatar/c5469c208eed4fccf3cc3bf885f48e10?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FVB-5.png" width="24" height="24" alt="victorbrenister@vandebron.nl" /> 
Reference ticket: [TECH-664](https://vandebron.atlassian.net/browse/TECH-664) 

👆 makes it a bit quicker to release tags into acceptance and production



**What**

from [2023-10-18+CI+CD+Guild](https://vandebron.atlassian.net/wiki/spaces/DIG/pages/95581544906767/2023-10-18+CI+CD+Guild) 

* deploy to production no longer deploys to test automatically in MPyL
* we want to have an option to deploy to test and acceptance together

**How**

* provide a new option to deploy to test/acce together in the jenkinsfile
Jenkinsfile (add new option here): [https://github.com/Vandebron/Vandebron/blob/master/deployment/pipeline/mpyl/Jenkinsfile](https://github.com/Vandebron/Vandebron/blob/master/deployment/pipeline/mpyl/Jenkinsfile)  
Pipeline:
[https://jenkins.k8s-serv-backend.vdbinfra.nl/view/MPyL/job/MPyL Pipeline/](https://jenkins.k8s-serv-backend.vdbinfra.nl/view/MPyL/job/MPyL%20Pipeline/)

* perform two runs in the jenkins pipeline:
**** first to acceptance
**** once that’s done, to test (this run will be fast because the build and test stages are cached)

**Testing**

* Open a PR with changes to the jenkinsfile
* Create dummy change in a project in the monorepo (should be reverted before merging)
* Run the pipeline for your PR (this will trigger the changed jenkinsfile)



Deadline: no strict ddl. 

We can contact someone from ci-cd guild to pair program

🏗️ Build [4](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-372/4/display/redirect) ✅ Successful, started by _Jorg Post_  
🚀 *[cloudfront-service](https://cloudfront-service-372.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-372.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-372.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[EA-186]: https://vandebron.atlassian.net/browse/EA-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ