### PR TITLE
do not filter project overrides from list of projects

### DIFF
--- a/releases/notes/1.5.0.md
+++ b/releases/notes/1.5.0.md
@@ -9,3 +9,6 @@ Add support for an argocd repository and workflow:
 - An additional `deployment.yaml` file will be created in the push command, it contains some extra metadata for argocd.
 - A pull request will be created in the configured argocd repository with the created k8s manifest files.
 - The folder in the argocd repo structure has the following pattern: `k8s-manifests/{project_name}/{target}/{namespace}/*.yaml`.
+
+#### Manual selection
+- Include project overrides in list of projects

--- a/src/mpyl/cli/projects.py
+++ b/src/mpyl/cli/projects.py
@@ -89,9 +89,8 @@ def list_projects(obj: ProjectsContext):
     found_projects = obj.cli.repo.find_projects(obj.filter)
 
     for proj in found_projects:
-        if OVERRIDE_PATTERN not in proj:
-            project = load_project(obj.cli.repo.root_dir, Path(proj), False)
-            obj.cli.console.print(Markdown(f"{proj} `{project.name}`"))
+        project = load_project(obj.cli.repo.root_dir, Path(proj), False)
+        obj.cli.console.print(Markdown(f"{proj} `{project.name}`"))
 
 
 @projects.command(name="names", help="List found project names")
@@ -103,7 +102,6 @@ def list_project_names(obj: ProjectsContext):
         [
             load_project(obj.cli.repo.root_dir, Path(proj), False).name
             for proj in found_projects
-            if OVERRIDE_PATTERN not in proj
         ]
     )
 

--- a/tests/cli/test_resources/list_projects_text.txt
+++ b/tests/cli/test_resources/list_projects_text.txt
@@ -4,7 +4,13 @@ tests/projects/dagster-user-code/deployment/project.yml
 [1;36;40mexample-dagster-user-code[0m                                                       
 tests/projects/ephemeral/deployment/project.yml [1;36;40mkong-sync[0m                       
 tests/projects/job/deployment/project.yml [1;36;40mjob[0m                                   
+tests/projects/overriden-project/deployment/project-override-first.yml          
+[1;36;40mocpp-first[0m                                                                      
+tests/projects/overriden-project/deployment/project-override-second.yml         
+[1;36;40mocpp-second[0m                                                                     
 tests/projects/overriden-project/deployment/project.yml [1;36;40mocpp[0m                    
 tests/projects/sbt-service/deployment/project.yml [1;36;40msbtservice[0m                    
 tests/projects/service/deployment/project.yml [1;36;40mnodeservice[0m                       
+tests/projects/spark-job/deployment/project-override-first.yml [1;36;40msparkJob-first[0m   
+tests/projects/spark-job/deployment/project-override-second.yml [1;36;40msparkJob-second[0m 
 tests/projects/spark-job/deployment/project.yml [1;36;40msparkJob[0m                        


### PR DESCRIPTION


----

### 📕 [GUILD-832](https://vandebron.atlassian.net/browse/GUILD-832) Fix manual deployment for overriden projects <img src="https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/6151b89d72f6970069e87968/a94f6e9a-3a6b-434f-926f-f4aa079c6a59/24" width="24" height="24" alt="danielkoves@vandebron.nl" /> 
[p1709627138180799](https://vandebron.slack.com/archives/CGJDDBETU/p1709627138180799) 

🏗️ Build [2](https://jenkins.k8s-serv-backend.vdbinfra.nl/job/MPyL%20Pipeline%20-%20Test/job/PR-373/2/display/redirect) ✅ Successful, started by _Daniel Koves_  
🚀 *[cloudfront-service](https://cloudfront-service-373.test.nl/swagger/index.html)*, *example-dagster-user-code*, *job*, *kong-sync*, *[nodeservice](https://nodeservice-373.test.nl/swagger/index.html)*, *ocpp-first*, *ocpp-second*, *[sbtservice](https://sbtservice-373.test.nl/swagger/index.html)*, *sparkJob-first*, *sparkJob-second*  


[GUILD-832]: https://vandebron.atlassian.net/browse/GUILD-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ