### PR TITLE
Also find projects on root level since gitpython uses git ls-files 's…

### DIFF
--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -349,11 +349,11 @@ class Repository:  # pylint: disable=too-many-public-methods
         """
         projects = set(
             self._repo.git.ls_files(
-                f"*{folder_pattern}*/{Project.project_yaml_path()}"
+                f"*{folder_pattern}*{Project.project_yaml_path()}"
             ).splitlines()
         ) | set(
             self._repo.git.ls_files(
-                f"*{folder_pattern}*/{Project.project_overrides_yml_pattern()}"
+                f"*{folder_pattern}*{Project.project_overrides_yml_pattern()}"
             ).splitlines()
         )
         return sorted(projects)


### PR DESCRIPTION
…tring'