### PR TITLE
feat: also clean the root .mpyl folder when calling mpyl build clean

### DIFF
--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -1,4 +1,5 @@
 """Commands related to build"""
+
 import asyncio
 import pickle
 import shutil
@@ -458,7 +459,7 @@ def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
         pass
 
 
-@build.command(help=f"Clean MPyL metadata in `{BUILD_ARTIFACTS_FOLDER}` folders")
+@build.command(help=f"Clean all MPyL metadata in `{BUILD_ARTIFACTS_FOLDER}` folders")
 @click.option(
     "--filter",
     "-f",
@@ -469,6 +470,11 @@ def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
 )
 @click.pass_obj
 def clean(obj: CliContext, filter_):
+    root_path = Path(BUILD_ARTIFACTS_FOLDER)
+    if root_path.is_dir():
+        shutil.rmtree(root_path)
+        obj.console.print(f"🧹 Cleaned up {root_path}")
+
     found_projects: list[Path] = [
         Path(
             load_project(

--- a/tests/cli/test_resources/build_help_text.txt
+++ b/tests/cli/test_resources/build_help_text.txt
@@ -11,7 +11,7 @@ Options:
 
 Commands:
   artifacts  Commands related to artifacts like build cache and k8s manifests
-  clean      Clean MPyL metadata in `.mpyl` folders
+  clean      Clean all MPyL metadata in `.mpyl` folders
   jenkins    Run a multi branch pipeline build on Jenkins
   run        Run an MPyL build
   status     The status of the current local branch from MPyL's perspective


### PR DESCRIPTION
This allows us to start a build from scratch by doing `mpyl build clean`, instead of having to support complex logic to understand when and how build plans should be used or cleaned up. 