### PR TITLE
refactor: renamed 'build plan' to 'run plan'

### DIFF
--- a/mpyl-reporter.py
+++ b/mpyl-reporter.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.logging import RichHandler
 
-from mpyl.constants import BUILD_ARTIFACTS_FOLDER
+from mpyl.constants import RUN_ARTIFACTS_FOLDER
 from mpyl.reporting.targets import ReportAccumulator
 from mpyl.reporting.targets.github import CommitCheck
 from mpyl.reporting.targets.github import PullRequestReporter
@@ -20,7 +20,7 @@ from mpyl.utilities.pyaml_env import parse_config
 
 
 def main(logger: Logger):
-    run_result_file = Path(BUILD_ARTIFACTS_FOLDER) / "run_result"
+    run_result_file = Path(RUN_ARTIFACTS_FOLDER) / "run_result"
 
     if not run_result_file.is_file():
         logger.info(f"Run result file {run_result_file} not found. Nothing to report.")

--- a/src/mpyl/artifacts/build_artifacts.py
+++ b/src/mpyl/artifacts/build_artifacts.py
@@ -15,7 +15,7 @@ from git.exc import GitCommandError
 from github import Github
 
 from ..cli.commands.build.jenkins import get_token
-from ..constants import BUILD_ARTIFACTS_FOLDER
+from ..constants import RUN_ARTIFACTS_FOLDER
 from ..project import Project, Target, load_project
 from ..steps.deploy.k8s.deploy_config import DeployConfig, get_namespace
 from ..steps.models import RunProperties
@@ -58,7 +58,7 @@ class BuildCacheTransformer(PathTransformer):
     def transform_for_read(self, project_path: str) -> Path:
         return Path(
             project_path.replace(
-                Project.project_yaml_path(), f"deployment/{BUILD_ARTIFACTS_FOLDER}"
+                Project.project_yaml_path(), f"deployment/{RUN_ARTIFACTS_FOLDER}"
             )
         )
 

--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -12,7 +12,7 @@ from rich.logging import RichHandler
 from rich.markdown import Markdown
 
 from .cli import CliContext, MpylCliParameters
-from .constants import DEFAULT_RUN_PROPERTIES_FILE_NAME, BUILD_ARTIFACTS_FOLDER
+from .constants import DEFAULT_RUN_PROPERTIES_FILE_NAME, RUN_ARTIFACTS_FOLDER
 from .reporting.formatting.markdown import (
     execution_plan_as_markdown,
     run_result_to_markdown,
@@ -53,7 +53,7 @@ def print_status(
                 for stage, project_executions in run_properties.run_plan.items()
             }
         )
-        run_plan_file = Path(BUILD_ARTIFACTS_FOLDER) / "build_plan.json"
+        run_plan_file = Path(RUN_ARTIFACTS_FOLDER) / "run_plan.json"
         os.makedirs(os.path.dirname(run_plan_file), exist_ok=True)
         with open(run_plan_file, "w", encoding="utf-8") as file:
             console.print(f"Writing simple JSON run plan to: {run_plan_file}")

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -37,7 +37,7 @@ from ..build import print_status, run_mpyl
 from ..constants import (
     DEFAULT_CONFIG_FILE_NAME,
     DEFAULT_RUN_PROPERTIES_FILE_NAME,
-    BUILD_ARTIFACTS_FOLDER,
+    RUN_ARTIFACTS_FOLDER,
 )
 from ..project import load_project, Target
 from ..run_plan import RunPlan
@@ -176,7 +176,7 @@ def run(
     projects,
     dryrun_,
 ):  # pylint: disable=invalid-name
-    run_result_file = Path(BUILD_ARTIFACTS_FOLDER) / "run_result"
+    run_result_file = Path(RUN_ARTIFACTS_FOLDER) / "run_result"
     if not sequential and run_result_file.is_file():
         run_result_file.unlink()
 
@@ -213,7 +213,7 @@ def run(
         run_properties=run_properties, cli_parameters=parameters, reporter=None
     )
 
-    Path(BUILD_ARTIFACTS_FOLDER).mkdir(parents=True, exist_ok=True)
+    Path(RUN_ARTIFACTS_FOLDER).mkdir(parents=True, exist_ok=True)
 
     if sequential and run_result_file.is_file():
         with open(run_result_file, "rb") as file:
@@ -460,7 +460,7 @@ def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
         pass
 
 
-@build.command(help=f"Clean all MPyL metadata in `{BUILD_ARTIFACTS_FOLDER}` folders")
+@build.command(help=f"Clean all MPyL metadata in `{RUN_ARTIFACTS_FOLDER}` folders")
 @click.option(
     "--filter",
     "-f",
@@ -471,7 +471,7 @@ def jenkins(  # pylint: disable=too-many-arguments, too-many-locals
 )
 @click.pass_obj
 def clean(obj: CliContext, filter_):
-    root_path = Path(BUILD_ARTIFACTS_FOLDER)
+    root_path = Path(RUN_ARTIFACTS_FOLDER)
     if root_path.is_dir():
         shutil.rmtree(root_path)
         obj.console.print(f"🧹 Cleaned up {root_path}")

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -216,7 +216,7 @@ def run(
     )
 
     Path(RUN_ARTIFACTS_FOLDER).mkdir(parents=True, exist_ok=True)
-    run_result_file = Path(BUILD_ARTIFACTS_FOLDER) / f"run_result-{uuid.uuid4()}.pickle"
+    run_result_file = Path(RUN_ARTIFACTS_FOLDER) / f"run_result-{uuid.uuid4()}.pickle"
     with open(run_result_file, "wb") as file:
         pickle.dump(run_result, file, pickle.HIGHEST_PROTOCOL)
 

--- a/src/mpyl/constants.py
+++ b/src/mpyl/constants.py
@@ -1,6 +1,6 @@
 """"Constants for mpyl."""
 
-BUILD_ARTIFACTS_FOLDER = ".mpyl"
+RUN_ARTIFACTS_FOLDER = ".mpyl"
 DEFAULT_CONFIG_FILE_NAME = "mpyl_config.yml"
 DEFAULT_RUN_PROPERTIES_FILE_NAME = "run_properties.yml"
 DEFAULT_STAGES_SCHEMA_FILE_NAME = "mpyl_stages.schema.yml"

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -26,7 +26,7 @@ import jsonschema
 from mypy.checker import Generic
 from ruamel.yaml import YAML
 
-from .constants import BUILD_ARTIFACTS_FOLDER
+from .constants import RUN_ARTIFACTS_FOLDER
 from .validation import validate
 
 T = TypeVar("T")
@@ -536,7 +536,7 @@ class Project:
 
     @property
     def target_path(self) -> str:
-        return str(Path(self.deployment_path, BUILD_ARTIFACTS_FOLDER))
+        return str(Path(self.deployment_path, RUN_ARTIFACTS_FOLDER))
 
     @property
     def test_containers_path(self) -> str:

--- a/src/mpyl/stages/discovery.py
+++ b/src/mpyl/stages/discovery.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from ..constants import BUILD_ARTIFACTS_FOLDER
+from ..constants import RUN_ARTIFACTS_FOLDER
 from ..project import Project
 from ..project import Stage
 from ..project_execution import ProjectExecution
@@ -249,7 +249,7 @@ def create_run_plan(  # pylint: disable=too-many-arguments, too-many-locals
 
     run_plan: RunPlan = RunPlan.empty()
 
-    run_plan_file = Path(BUILD_ARTIFACTS_FOLDER) / "build_plan"
+    run_plan_file = Path(RUN_ARTIFACTS_FOLDER) / "run_plan"
     if sequential and not build_all and not selected_projects:
         if not run_plan_file.is_file():
             logger.warning(

--- a/src/mpyl/steps/build/docker_build.py
+++ b/src/mpyl/steps/build/docker_build.py
@@ -17,6 +17,7 @@ to a folder named `$WORKDIR/target/test-reports/`.
 .. include:: ../../../../tests/projects/service/deployment/Dockerfile-mpl
 ```
 """
+
 import os
 from logging import Logger
 
@@ -24,7 +25,7 @@ from .post_docker_build import AfterBuildDocker
 from .. import Step, Meta
 from ..models import Input, Output, ArtifactType, input_to_artifact
 from . import STAGE_NAME
-from ...constants import BUILD_ARTIFACTS_FOLDER
+from ...constants import RUN_ARTIFACTS_FOLDER
 from ...utilities import replace_pr_number
 from ...utilities.docker import (
     DockerConfig,
@@ -38,7 +39,7 @@ from ...utilities.docker import (
     full_image_path_for_project,
 )
 
-DOCKER_IGNORE_DEFAULT = ["**/target/*", f"**/{BUILD_ARTIFACTS_FOLDER}/*"]
+DOCKER_IGNORE_DEFAULT = ["**/target/*", f"**/{RUN_ARTIFACTS_FOLDER}/*"]
 
 
 class BuildDocker(Step):

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -7,7 +7,7 @@ from jsonschema import ValidationError
 from pyaml_env import parse_config
 from ruamel.yaml import YAML  # type: ignore
 
-from src.mpyl.constants import DEFAULT_CONFIG_FILE_NAME, BUILD_ARTIFACTS_FOLDER
+from src.mpyl.constants import DEFAULT_CONFIG_FILE_NAME, RUN_ARTIFACTS_FOLDER
 from src.mpyl.project import Project, Stages, Target, Dependencies
 from src.mpyl.project_execution import ProjectExecution
 from src.mpyl.projects.versioning import yaml_to_string
@@ -68,7 +68,7 @@ class TestSteps:
     def test_write_output(self):
         build_yaml = yaml_to_string(self.docker_image, yaml)
         assert_roundtrip(
-            test_resource_path / "deployment" / BUILD_ARTIFACTS_FOLDER / "build.yml",
+            test_resource_path / "deployment" / RUN_ARTIFACTS_FOLDER / "build.yml",
             build_yaml,
         )
 
@@ -86,7 +86,7 @@ class TestSteps:
         )
 
         assert_roundtrip(
-            test_resource_path / "deployment" / BUILD_ARTIFACTS_FOLDER / "deploy.yml",
+            test_resource_path / "deployment" / RUN_ARTIFACTS_FOLDER / "deploy.yml",
             yaml_to_string(output, yaml),
         )
 


### PR DESCRIPTION
The name `build_plan` causes a lot of confusion since it clashes with the _Build_ stage and the `Sbt Build` and `Docker Build` steps. For this reason, after aligning all variables (from "build plan" or "build set" to "run plan") we're now also aligning the name of the file produced.

Replaces https://github.com/Vandebron/mpyl/pull/405