### PR TITLE
feat: always produce hashed contents if changes are available

### DIFF
--- a/src/mpyl/project_execution.py
+++ b/src/mpyl/project_execution.py
@@ -1,6 +1,5 @@
 """This module contains the ProjectExecution class."""
 
-import uuid
 from dataclasses import dataclass
 from typing import Optional
 

--- a/src/mpyl/project_execution.py
+++ b/src/mpyl/project_execution.py
@@ -1,6 +1,8 @@
 """This module contains the ProjectExecution class."""
+
 import uuid
 from dataclasses import dataclass
+from typing import Optional
 
 from .project import Project
 
@@ -8,14 +10,25 @@ from .project import Project
 @dataclass(frozen=True)
 class ProjectExecution:
     project: Project
-    cache_key: str
+    hashed_changes: Optional[str]
     cached: bool
 
     @staticmethod
-    def always_run(project: Project):
-        """Create a ProjectExecution for a project that will always run, regardless of caching"""
+    def create(project: Project, cached: bool, hashed_changes: Optional[str] = None):
+        if cached:
+            return ProjectExecution.skip(project, hashed_changes)
+        return ProjectExecution.run(project, hashed_changes)
+
+    @staticmethod
+    def skip(project: Project, hashed_changes: Optional[str] = None):
         return ProjectExecution(
-            project=project, cache_key=uuid.uuid4().hex, cached=False
+            project=project, hashed_changes=hashed_changes, cached=True
+        )
+
+    @staticmethod
+    def run(project: Project, hashed_changes: Optional[str] = None):
+        return ProjectExecution(
+            project=project, hashed_changes=hashed_changes, cached=False
         )
 
     @property

--- a/src/mpyl/stages/discovery.py
+++ b/src/mpyl/stages/discovery.py
@@ -93,49 +93,53 @@ def is_project_cached_for_stage(
     project: str,
     stage: str,
     output: Optional[Output],
-    cache_key: str,
+    hashed_changes: Optional[str],
 ) -> bool:
     cached = False
 
     if stage == deploy.STAGE_NAME:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because this stage is never cached"
+            f"Project {project} will execute stage {stage} because this stage is never cached"
         )
     elif output is None:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because there is no previous run"
+            f"Project {project} will execute stage {stage} because there is no previous run"
         )
     elif not output.success:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because the previous run was not successful"
+            f"Project {project} will execute stage {stage} because the previous run was not successful"
         )
     elif output.produced_artifact is None:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because there was no artifact in the previous run"
+            f"Project {project} will execute stage {stage} because there was no artifact in the previous run"
         )
     elif not output.produced_artifact.hash:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because there is no cache key in the previous run"
+            f"Project {project} will execute stage {stage} because there are no hashed changes for the previous run"
         )
-    elif output.produced_artifact.hash != cache_key:
+    elif not hashed_changes:
         logger.debug(
-            f"Project {project} will execute stage {stage} again because its content changed since the previous run"
+            f"Project {project} will execute stage {stage} because there are no hashed changes for the current run"
+        )
+    elif output.produced_artifact.hash != hashed_changes:
+        logger.debug(
+            f"Project {project} will execute stage {stage} because its content changed since the previous run"
         )
         logger.debug(
-            f"Hash of contents for previous run: {output.produced_artifact.hash}"
+            f"Hashed changes for the previous run: {output.produced_artifact.hash}"
         )
-        logger.debug(f"Hash of contents for current run:  {cache_key}")
+        logger.debug(f"Hashed changes for the current run:  {hashed_changes}")
     else:
         logger.debug(
             f"Project {project} will skip stage {stage} because its content did not change since the previous run"
         )
-        logger.debug(f"Hash of contents for current run: {cache_key}")
+        logger.debug(f"Hashed changes for the current run: {hashed_changes}")
         cached = True
 
     return cached
 
 
-def _cache_key_from_changes_in_project(
+def _hash_changes_in_project(
     logger: logging.Logger,
     project: Project,
     changeset: Changeset,
@@ -172,30 +176,20 @@ def to_project_executions(
     def to_project_execution(
         project: Project,
     ) -> ProjectExecution:
-        cache_key = _cache_key_from_changes_in_project(
+        hashed_changes = _hash_changes_in_project(
             logger=logger, project=project, changeset=changeset
         )
 
-        if cache_key:
-            logger.debug(
-                f"Project {project.name}: using hash of modified files as cache key {cache_key}"
-            )
-        else:
-            logger.debug(
-                f"Project {project.name}: no content changes, falling back to revision as cache key: {changeset.sha}"
-            )
-            cache_key = changeset.sha
-
-        return ProjectExecution(
+        return ProjectExecution.create(
             project=project,
-            cache_key=cache_key,
             cached=is_project_cached_for_stage(
                 logger=logger,
                 project=project.name,
                 stage=stage,
                 output=Output.try_read(project.target_path, stage),
-                cache_key=cache_key,
+                hashed_changes=hashed_changes,
             ),
+            hashed_changes=hashed_changes,
         )
 
     return set(map(to_project_execution, projects))
@@ -227,39 +221,31 @@ def find_projects_to_execute(
             logger.debug(
                 f"Project {project} will execute stage {stage} because a dependency was modified"
             )
-            # pylint: disable=fixme
-            # FIXME ptab we should still calculate a hash (in case files changed) to speed up a possible next build
-            # this will come in a following PR
-            return ProjectExecution.always_run(project)
 
-        if is_project_modified:
-            cache_key = _cache_key_from_changes_in_project(
-                logger=logger, project=project, changeset=changeset
-            )
-            if cache_key:
-                logger.debug(
-                    f"Project {project.name}: using hash of modified files as cache key {cache_key}"
+            if is_project_modified:
+                hashed_changes = _hash_changes_in_project(
+                    logger=logger, project=project, changeset=changeset
                 )
             else:
-                # pylint: disable=fixme
-                # FIXME ptab using revision as a cache_key makes no sense, as we will never check against
-                #  that commit against. Would be simpler just to fallback to the UUID generation here for consistency.
-                logger.debug(
-                    f"Project {project.name}: no content changes, falling back to revision as"
-                    f" cache key: {changeset.sha}"
-                )
-                cache_key = changeset.sha
+                hashed_changes = None
 
-            return ProjectExecution(
+            return ProjectExecution.run(project, hashed_changes)
+
+        if is_project_modified:
+            hashed_changes = _hash_changes_in_project(
+                logger=logger, project=project, changeset=changeset
+            )
+
+            return ProjectExecution.create(
                 project=project,
-                cache_key=cache_key,
                 cached=is_project_cached_for_stage(
                     logger=logger,
                     project=project.name,
                     stage=stage,
                     output=Output.try_read(project.target_path, stage),
-                    cache_key=cache_key,
+                    hashed_changes=hashed_changes,
                 ),
+                hashed_changes=hashed_changes,
             )
 
         return None

--- a/src/mpyl/steps/build/post_docker_build.py
+++ b/src/mpyl/steps/build/post_docker_build.py
@@ -45,7 +45,7 @@ class AfterBuildDocker(Step):
             revision=properties.versioning.revision,
             producing_step=self.meta.name,
             spec=DockerImageSpec(image=full_image_path),
-            hash=step_input.project_execution.cache_key,
+            hash=step_input.project_execution.hashed_changes,
         )
 
         if step_input.dry_run:

--- a/src/mpyl/steps/models.py
+++ b/src/mpyl/steps/models.py
@@ -281,7 +281,7 @@ def input_to_artifact(
     return Artifact(
         artifact_type=artifact_type,
         revision=step_input.run_properties.versioning.revision,
-        hash=step_input.project_execution.cache_key,
+        hash=step_input.project_execution.hashed_changes,
         producing_step=step_input.project_execution.name,
         spec=spec,
     )

--- a/src/mpyl/steps/postdeploy/cypress_test.py
+++ b/src/mpyl/steps/postdeploy/cypress_test.py
@@ -1,4 +1,5 @@
 """ Step that runs relevant cypress tests in the post deploy stage """
+
 import os
 from logging import Logger
 

--- a/tests/cli/commands/test_build.py
+++ b/tests/cli/commands/test_build.py
@@ -62,7 +62,7 @@ class TestBuildCommand:
         assert result.status_line == "🦥 Nothing to do"
 
     def test_run_build_with_plan_should_execute_successfully(self):
-        project_executions = {ProjectExecution.always_run(get_minimal_project())}
+        project_executions = {ProjectExecution.run(get_minimal_project())}
         run_plan = RunPlan(
             {
                 TestStage.build(): project_executions,
@@ -88,7 +88,7 @@ class TestBuildCommand:
     def test_run_build_throwing_step_should_be_handled(self):
         projects = {get_project_with_stages({"build": "Throwing Build"})}
         run_plan = RunPlan(
-            {TestStage.build(): {ProjectExecution.always_run(p) for p in projects}}
+            {TestStage.build(): {ProjectExecution.run(p) for p in projects}}
         )
         run_properties = construct_run_properties(
             config=config_values,

--- a/tests/reporting/__init__.py
+++ b/tests/reporting/__init__.py
@@ -38,13 +38,11 @@ def create_test_result_with_plan() -> RunResult:
             run_plan=RunPlan(
                 {
                     TestStage.build(): {
-                        ProjectExecution.always_run(p) for p in build_projects
+                        ProjectExecution.run(p) for p in build_projects
                     },
-                    TestStage.test(): {
-                        ProjectExecution.always_run(p) for p in test_projects
-                    },
+                    TestStage.test(): {ProjectExecution.run(p) for p in test_projects},
                     TestStage.deploy(): {
-                        ProjectExecution.always_run(p) for p in deploy_projects
+                        ProjectExecution.run(p) for p in deploy_projects
                     },
                 }
             ),

--- a/tests/steps/deploy/dagster/test_dagster.py
+++ b/tests/steps/deploy/dagster/test_dagster.py
@@ -38,7 +38,7 @@ class TestDagster:
 
     def test_generate_correct_values_yaml_with_service_account_override(self):
         step_input = Input(
-            ProjectExecution.always_run(
+            ProjectExecution.run(
                 project=load_project(
                     test_resource_path, self.resource_path / "project.yml", True
                 )
@@ -64,7 +64,7 @@ class TestDagster:
 
     def test_generate_correct_values_yaml_with_production_target(self):
         step_input = Input(
-            ProjectExecution.always_run(
+            ProjectExecution.run(
                 project=load_project(
                     test_resource_path, Path(self.resource_path, "project.yml"), True
                 ),
@@ -88,7 +88,7 @@ class TestDagster:
 
     def test_generate_correct_values_yaml_without_service_account_override(self):
         step_input = Input(
-            ProjectExecution.always_run(
+            ProjectExecution.run(
                 project=load_project(
                     test_resource_path, Path(self.resource_path, "project.yml"), True
                 )
@@ -115,7 +115,7 @@ class TestDagster:
     def test_generate_with_sealed_secret_as_extra_manifest(self):
         project_folder = self.config_resource_path / ".." / self.dagster_project_folder
         step_input = Input(
-            ProjectExecution.always_run(
+            ProjectExecution.run(
                 project=load_project(
                     self.config_resource_path,
                     project_folder / "project_with_sealed_secret.yml",

--- a/tests/steps/deploy/ephemeral/test_ephemeral.py
+++ b/tests/steps/deploy/ephemeral/test_ephemeral.py
@@ -11,7 +11,7 @@ class TestEphemeral:
 
     def test_get_env_variables_for_target(self):
         step_input = Input(
-            ProjectExecution.always_run(
+            ProjectExecution.run(
                 load_project(
                     self.config_resource_path, self.resource_path / "project.yml", True
                 )

--- a/tests/steps/deploy/k8s/test_k8s.py
+++ b/tests/steps/deploy/k8s/test_k8s.py
@@ -59,7 +59,7 @@ class TestKubernetesChart:
 
     @staticmethod
     def _get_builder(project: Project, run_properties=None):
-        project_execution = ProjectExecution.always_run(project)
+        project_execution = ProjectExecution.run(project)
 
         if not run_properties:
             project_executions = {project_execution}

--- a/tests/steps/post_deploy/test_cypress.py
+++ b/tests/steps/post_deploy/test_cypress.py
@@ -35,7 +35,7 @@ class TestCypress:
         with pytest.raises(ExecutionException) as exc_info:
             self.executor.execute(
                 stage=postdeploy.STAGE_NAME,
-                project_execution=ProjectExecution.always_run(project),
+                project_execution=ProjectExecution.run(project),
             )
 
         assert "No cypress specs are defined in the project dependencies" in str(

--- a/tests/steps/test_steps.py
+++ b/tests/steps/test_steps.py
@@ -135,7 +135,7 @@ class TestSteps:
         )
         output = steps.execute(
             stage=build.STAGE_NAME,
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         ).output
         assert not output.success
         assert output.message == "Stage 'build' not defined on project 'test'"
@@ -167,7 +167,7 @@ class TestSteps:
         project = test_data.get_project_with_stages({"build": "Echo Build"})
         result = self.executor.execute(
             stage=build.STAGE_NAME,
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         )
         assert result.output.success
         assert result.output.message == "Built test"
@@ -180,7 +180,7 @@ class TestSteps:
         project = test_data.get_project_with_stages({"build": "Unknown Build"})
         result = self.executor.execute(
             stage=build.STAGE_NAME,
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         )
         assert not result.output.success
         assert (
@@ -195,7 +195,7 @@ class TestSteps:
 
         result = self.executor.execute(
             stage=build.STAGE_NAME,
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         )
         assert not result.output.success
         assert (
@@ -207,7 +207,7 @@ class TestSteps:
         project = test_data.get_project_with_stages(stage_config={"test": "Some Test"})
         result = self.executor.execute(
             stage="build",
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         )
         assert not result.output.success
         assert result.output.message == "Stage 'build' not defined on project 'test'"
@@ -228,6 +228,6 @@ class TestSteps:
         )
         result = self.executor.execute(
             stage=postdeploy.STAGE_NAME,
-            project_execution=ProjectExecution.always_run(project),
+            project_execution=ProjectExecution.run(project),
         )
         assert result.output.success

--- a/tests/test_resources/test_data.py
+++ b/tests/test_resources/test_data.py
@@ -69,7 +69,7 @@ def get_project() -> Project:
 
 
 def get_project_execution() -> ProjectExecution:
-    return ProjectExecution.always_run(get_project())
+    return ProjectExecution.run(get_project())
 
 
 def get_deployment_strategy_project() -> Project:
@@ -112,9 +112,7 @@ def run_properties_with_plan(plan: RunPlan) -> RunProperties:
 
 
 def run_properties_prod_with_plan() -> RunProperties:
-    plan = RunPlan(
-        {TestStage.deploy(): {ProjectExecution.always_run(get_minimal_project())}}
-    )
+    plan = RunPlan({TestStage.deploy(): {ProjectExecution.run(get_minimal_project())}})
     run_properties_prod = construct_run_properties(
         config=config_values,
         properties=properties_values,


### PR DESCRIPTION
The current implementation needlessly links the fact that the current run can be cached to the production a hash of the contents, which means in some cases forcing a stage to run regardless of its caching status also prevents the next run from being cached.

This PR fixes that by ensuring that, regardless of whether the current run uses cached contents or re-runs the stage, a hash of the changes is always generated.