### PR TITLE
feat: add tag parameter to build status

### DIFF
--- a/src/mpyl/build.py
+++ b/src/mpyl/build.py
@@ -64,7 +64,7 @@ def print_status(
     console.print(f"MPyL log level is set to {run_properties.console.log_level}")
     branch = obj.repo.get_branch
     main_branch = obj.repo.main_branch
-    tag = run_properties.versioning.tag
+    tag = cli_params.tag or run_properties.versioning.tag
 
     if tag is None:
         if run_properties.versioning.branch and not obj.repo.get_branch:

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -243,6 +243,7 @@ def run(
     required=False,
     help="Stage to get status for",
 )
+@click.option("--tag", "-t", help="Tag to build", type=click.STRING, required=False)
 @click.option("--explain", "-e", is_flag=True, help="Explain the current run plan")
 @click.pass_obj
 def status(obj: CliContext, all_, projects, stage, explain):

--- a/src/mpyl/cli/build.py
+++ b/src/mpyl/cli/build.py
@@ -246,12 +246,12 @@ def run(
 @click.option("--tag", "-t", help="Tag to build", type=click.STRING, required=False)
 @click.option("--explain", "-e", is_flag=True, help="Explain the current run plan")
 @click.pass_obj
-def status(obj: CliContext, all_, projects, stage, explain):
+def status(obj: CliContext, all_, projects, stage, tag, explain):
     upgrade_check = None
     try:
         upgrade_check = asyncio.wait_for(warn_if_update(obj.console), timeout=3)
         parameters = MpylCliParameters(
-            local=sys.stdout.isatty(), all=all_, projects=projects, stage=stage
+            local=sys.stdout.isatty(), all=all_, projects=projects, stage=stage, tag=tag
         )
         print_status(obj, parameters, explain)
     except asyncio.exceptions.TimeoutError:


### PR DESCRIPTION
In order to create a build plan for a tag release, `mpyl build status` should support a `--tag` parameter like the other build commands.