### PR TITLE
refactor: simpler logging

### DIFF
--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -42,7 +42,8 @@ def custom_check_output(
                     f"Process {command_argument} does not have an stdout"
                 )
 
-            for line in process.stdout:
+            while process.poll() is None:
+                line = process.stdout.readline().rstrip()
                 if use_print:
                     print(line)
                 else:

--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -42,16 +42,13 @@ def custom_check_output(
                     f"Process {command_argument} does not have an stdout"
                 )
 
-            for line in iter(process.stdout.readline, ""):
-                if line:
-                    stripped_line = line.rstrip()
-                    if use_print:
-                        print(stripped_line)
-                    else:
-                        logger.info(try_parse_ansi(stripped_line))
+            for line in process.stdout:
+                stripped_line = line.rstrip()
+                if use_print:
+                    print(stripped_line)
+                else:
+                    logger.info(try_parse_ansi(stripped_line))
 
-                if process.poll() is not None:
-                    break
             success = process.wait() == 0
             if not success:
                 if process.stderr:

--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -42,8 +42,7 @@ def custom_check_output(
                     f"Process {command_argument} does not have an stdout"
                 )
 
-            while process.poll() is None:
-                line = process.stdout.readline().rstrip()
+            for line in process.stdout:
                 if use_print:
                     print(line)
                 else:

--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -43,11 +43,10 @@ def custom_check_output(
                 )
 
             for line in process.stdout:
-                stripped_line = line.rstrip()
                 if use_print:
-                    print(stripped_line)
+                    print(line)
                 else:
-                    logger.info(try_parse_ansi(stripped_line))
+                    logger.info(try_parse_ansi(line))
 
             success = process.wait() == 0
             if not success:


### PR DESCRIPTION
This is technically not necessary anymore, but it might be good to simplify the code since the behaviour of `readline()` and `for line in file-object` was aligned in Python 3.