### PR TITLE
Add docker as generic docker registry host

### DIFF
--- a/.github/setup-kind/action.yaml
+++ b/.github/setup-kind/action.yaml
@@ -4,8 +4,8 @@ description: 'Creates an in-memory Kubernetes cluster with the required dependen
 runs:
   using: composite
   steps:
-    - uses: azure/setup-helm@v3.5
-    - uses: helm/kind-action@v1.8.0
+    - uses: azure/setup-helm@v4.2.0
+    - uses: helm/kind-action@v1.10.0
 
     - name: 'Add extra repositories'
       run: |

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -8,8 +8,8 @@ jobs:
     name: 🧽 Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: cache-dependencies
         with:
           python-version: '3.9'
@@ -37,8 +37,8 @@ jobs:
     name: 🧐 Check types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: cache-dependencies
         with:
           python-version: '3.9'
@@ -63,8 +63,8 @@ jobs:
     name: 🧪 Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: cache-dependencies
         with:
           python-version: '3.9'
@@ -120,8 +120,8 @@ jobs:
     outputs:
       mpylVersion: ${{ steps.version.outputs.mpylVersion }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: cache-dependencies
         with:
           python-version: '3.9'
@@ -179,7 +179,7 @@ jobs:
     env:
       MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -220,7 +220,7 @@ jobs:
     env:
       MPYL_CONFIG_PATH: mpyl_config.example.yml
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         id: install-python
         with:
           python-version: '3.9'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 100

--- a/src/mpyl/schema/mpyl_config.schema.yml
+++ b/src/mpyl/schema/mpyl_config.schema.yml
@@ -301,6 +301,7 @@ definitions:
         enum:
           - 'aws'
           - 'azure'
+          - 'docker'
         description: >-
           Defines the container registry provider. Defaults to aws.
         default: 'aws'

--- a/src/mpyl/utilities/docker/__init__.py
+++ b/src/mpyl/utilities/docker/__init__.py
@@ -124,6 +124,7 @@ class DockerConfig:
 class Provider(Enum):
     AWS = "aws"
     AZURE = "azure"
+    DOCKER = "docker"
 
 
 def execute_with_stream(
@@ -332,22 +333,18 @@ def build(
 
 def login(logger: Logger, registry_config: DockerRegistryConfig) -> None:
     logger.info(f"Logging in with user '{registry_config.user_name}'")
-    if registry_config.provider == Provider.AZURE.value:  # pylint: disable=no-member
+    if registry_config.provider != Provider.AWS.value:  # pylint: disable=no-member
         docker.login(
             server=f"https://{registry_config.host_name}",
             username=registry_config.user_name,
             password=registry_config.password,
         )
-    elif registry_config.provider == Provider.AWS.value:  # pylint: disable=no-member
+    else:
         docker.login_ecr(
             aws_access_key_id=registry_config.user_name,
             aws_secret_access_key=registry_config.password,
             region_name=registry_config.region,
             registry=registry_config.host_name,
-        )
-    else:
-        raise ValueError(
-            f"Docker config has no container registry provider with name {registry_config.provider}"
         )
     logger.debug(f"Logged in as '{registry_config.user_name}'")
 


### PR DESCRIPTION
Schema documentation says 'aws' is the default registry provider. The
code now falls back on 'aws' when the provider is unspecified, making
what the documentation says true.
