### PR TITLE
fix: avoid empty lines everywhere; also print messages sent to stderr

### DIFF
--- a/src/mpyl/utilities/subprocess/__init__.py
+++ b/src/mpyl/utilities/subprocess/__init__.py
@@ -36,7 +36,9 @@ def custom_check_output(
             )
             return Output(success=True, message=out)
 
-        with subprocess.Popen(command, stdout=subprocess.PIPE, text=True) as process:
+        with subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ) as process:
             if not process.stdout:
                 raise RuntimeError(
                     f"Process {command_argument} does not have an stdout"
@@ -44,9 +46,9 @@ def custom_check_output(
 
             for line in process.stdout:
                 if use_print:
-                    print(line)
+                    print(line.rstrip())
                 else:
-                    logger.info(try_parse_ansi(line))
+                    logger.info(try_parse_ansi(line.rstrip()))
 
             success = process.wait() == 0
             if not success:


### PR DESCRIPTION
Turn this:
![image](https://github.com/Vandebron/mpyl/assets/516602/c6063487-e926-418a-833b-3cb741309c7b)
Into this:
![image](https://github.com/Vandebron/mpyl/assets/516602/42574a38-b617-4e18-8464-bc118bc1b300)
