### PR TITLE
fix: revert back to the traefik.containo.us api version

### DIFF
--- a/.github/setup-kind/action.yaml
+++ b/.github/setup-kind/action.yaml
@@ -1,6 +1,20 @@
 name: 'Setup Helm chart testing infrastructure'
 description: 'Creates an in-memory Kubernetes cluster with the required dependencies to test Helm charts'
 
+inputs:
+  traefik-version:
+    description: The version of Traefik to install
+    required: true
+  prometheus-version:
+    description: The version of Prometheus to install
+    required: true
+  sealed-secrets-version:
+    description: The version of Sealed Secrets to install
+    required: true
+  spark-operator-version:
+    description: The version of Spark Operator to install
+    required: true
+
 runs:
   using: composite
   steps:
@@ -16,14 +30,22 @@ runs:
         helm repo update
       shell: bash
 
-    - run: helm install traefik traefik/traefik
+    - run: helm install traefik traefik/traefik --version "$VERSION"
       shell: bash
+      env:
+        VERSION: ${{ inputs.traefik-version }}
 
-    - run: helm install kube-prometheus prometheus-community/kube-prometheus-stack
+    - run: helm install kube-prometheus prometheus-community/kube-prometheus-stack --version "$VERSION"
       shell: bash
+      env:
+        VERSION: ${{ inputs.prometheus-version }}
 
-    - run: helm install sealed-secrets sealed-secrets/sealed-secrets
+    - run: helm install sealed-secrets sealed-secrets/sealed-secrets --version "$VERSION"
       shell: bash
+      env:
+        VERSION: ${{ inputs.sealed-secrets-version }}
 
-    - run: helm install spark-operator spark-operator/spark-operator
+    - run: helm install spark-operator spark-operator/spark-operator --version "$VERSION"
       shell: bash
+      env:
+        VERSION: ${{ inputs.spark-operator-version }}

--- a/.github/setup-kind/action.yaml
+++ b/.github/setup-kind/action.yaml
@@ -2,17 +2,17 @@ name: 'Setup Helm chart testing infrastructure'
 description: 'Creates an in-memory Kubernetes cluster with the required dependencies to test Helm charts'
 
 inputs:
-  traefik-version:
-    description: The version of Traefik to install
+  traefik-chart-version:
+    description: The version of the Traefik Helm chart to install
     required: true
-  prometheus-version:
-    description: The version of Prometheus to install
+  prometheus-chart-version:
+    description: The version of the Prometheus Helm chart to install
     required: true
-  sealed-secrets-version:
-    description: The version of Sealed Secrets to install
+  sealed-secrets-chart-version:
+    description: The version of the Sealed Secrets Helm chart to install
     required: true
-  spark-operator-version:
-    description: The version of Spark Operator to install
+  spark-operator-chart-version:
+    description: The version of the Spark Operator Helm chart to install
     required: true
 
 runs:
@@ -33,19 +33,19 @@ runs:
     - run: helm install traefik traefik/traefik --version "$VERSION"
       shell: bash
       env:
-        VERSION: ${{ inputs.traefik-version }}
+        VERSION: ${{ inputs.traefik-chart-version }}
 
     - run: helm install kube-prometheus prometheus-community/kube-prometheus-stack --version "$VERSION"
       shell: bash
       env:
-        VERSION: ${{ inputs.prometheus-version }}
+        VERSION: ${{ inputs.prometheus-chart-version }}
 
     - run: helm install sealed-secrets sealed-secrets/sealed-secrets --version "$VERSION"
       shell: bash
       env:
-        VERSION: ${{ inputs.sealed-secrets-version }}
+        VERSION: ${{ inputs.sealed-secrets-chart-version }}
 
     - run: helm install spark-operator spark-operator/spark-operator --version "$VERSION"
       shell: bash
       env:
-        VERSION: ${{ inputs.spark-operator-version }}
+        VERSION: ${{ inputs.spark-operator-chart-version }}

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -195,6 +195,11 @@ jobs:
           fetch-depth: 0
 
       - uses: Vandebron/mpyl/.github/setup-kind@main
+        with:
+          traefik-version: 2.11.2
+          prometheus-version: 2.42.0
+          sealed-secrets-version: 2.7.6
+          spark-operator-version: 1.1.25
 
       - name: Check mpyl health
         run: mpyl health --ci

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -196,10 +196,10 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-version: 2.11.2
-          prometheus-version: 2.42.0
-          sealed-secrets-version: 2.7.6
-          spark-operator-version: 1.1.25
+          traefik-chart-version: 27.0.2
+          prometheus-chart-version: 60.3.0
+          sealed-secrets-chart-version: 2.16.0
+          spark-operator-chart-version: 1.4.2
 
       - name: Check mpyl health
         run: mpyl health --ci
@@ -240,7 +240,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Vandebron/mpyl/.github/setup-kind@main
+      - uses: ./.github/setup-kind
+        with:
+          traefik-version: 2.11.2
+          prometheus-version: 2.42.0
+          sealed-secrets-version: 2.7.6
+          spark-operator-version: 1.1.25
 
       - name: Get head revision
         id: headRevision

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -242,10 +242,10 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-version: 2.11.2
-          prometheus-version: 2.42.0
-          sealed-secrets-version: 2.7.6
-          spark-operator-version: 1.1.25
+          traefik-chart-version: 27.0.2
+          prometheus-chart-version: 60.3.0
+          sealed-secrets-chart-version: 2.16.0
+          spark-operator-chart-version: 1.4.2
 
       - name: Get head revision
         id: headRevision

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -198,8 +198,8 @@ jobs:
         with:
           traefik-chart-version: 27.0.2
           prometheus-chart-version: 60.3.0
-          sealed-secrets-chart-version: 2.16.0
-          spark-operator-chart-version: 1.4.2
+          sealed-secrets-chart-version: 2.7.3
+          spark-operator-chart-version: 1.1.25
 
       - name: Check mpyl health
         run: mpyl health --ci
@@ -244,8 +244,8 @@ jobs:
         with:
           traefik-chart-version: 27.0.2
           prometheus-chart-version: 60.3.0
-          sealed-secrets-chart-version: 2.16.0
-          spark-operator-chart-version: 1.4.2
+          sealed-secrets-chart-version: 2.7.3
+          spark-operator-chart-version: 1.1.25
 
       - name: Get head revision
         id: headRevision

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -194,7 +194,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: Vandebron/mpyl/.github/setup-kind@main
+      - uses: ./.github/setup-kind
         with:
           traefik-version: 2.11.2
           prometheus-version: 2.42.0

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -1,6 +1,7 @@
 """
 This module contains the traefik ingress route CRD.
 """
+
 from dataclasses import dataclass
 from typing import Optional, Union, Any
 
@@ -67,7 +68,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
             tls |= {"options": {"name": "insecure-ciphers", "namespace": "traefik"}}
 
         super().__init__(
-            api_version="traefik.io/v1alpha1",
+            api_version="traefik.containo.us/v1alpha1",
             kind="IngressRoute",
             metadata=metadata,
             spec={
@@ -82,7 +83,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
 class V1AlphaMiddleware(CustomResourceDefinition):
     def __init__(self, metadata: V1ObjectMeta, source_ranges: list[str]):
         super().__init__(
-            api_version="traefik.io/v1alpha1",
+            api_version="traefik.containo.us/v1alpha1",
             kind="Middleware",
             metadata=metadata,
             spec={"ipWhiteList": {"sourceRange": source_ranges}},

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   annotations:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   annotations:

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: dockertest
 ---
 # dockertest-ingress-0-http
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -138,7 +138,7 @@ spec:
   - web
 ---
 # dockertest-ingress-0-https
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -170,7 +170,7 @@ spec:
       namespace: traefik
 ---
 # dockertest-ingress-0-whitelist
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   annotations:
@@ -191,7 +191,7 @@ spec:
     - 10.0.0.1
 ---
 # dockertest-ingress-1-http
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -220,7 +220,7 @@ spec:
   - web
 ---
 # dockertest-ingress-1-https
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -250,7 +250,7 @@ spec:
     secretName: le-other-prod-wildcard-cert
 ---
 # dockertest-ingress-1-whitelist
-apiVersion: traefik.io/v1alpha1
+apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   annotations:


### PR DESCRIPTION
Our platform is not ready for this upgrade so we need to go back to the old `apiVersion` value.