### PR TITLE
fix: Force ArgoCD to replace Jobs when syncing

### DIFF
--- a/src/mpyl/steps/deploy/k8s/chart.py
+++ b/src/mpyl/steps/deploy/k8s/chart.py
@@ -422,7 +422,11 @@ class ChartBuilder:
         return V1Job(
             api_version="batch/v1",
             kind="Job",
-            metadata=self._to_object_meta(),
+            metadata=self._to_object_meta(
+                annotations={
+                    "argocd.argoproj.io/sync-options": "Force=true,Replace=true"
+                }
+            ),
             spec=spec,
         )
 

--- a/tests/steps/deploy/k8s/chart/templates/job/job.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/job.yaml
@@ -1,6 +1,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   labels:
     name: job
     app.kubernetes.io/version: pr-1234


### PR DESCRIPTION
MPyL inherently deletes and deploys `Job`s in K8s because they modify immutable fields. To ensure same behavior across ArgoCD implementations, we added this annotation.