### PR TITLE
feat: support new Traefik 3 API version and configuration syntax

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -196,7 +196,7 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-chart-version: 31.1.1
+          traefik-chart-version: 27.0.2
           prometheus-chart-version: 60.3.0
           sealed-secrets-chart-version: 2.7.3
           spark-operator-chart-version: 1.1.25
@@ -242,7 +242,7 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-chart-version: 31.1.1
+          traefik-chart-version: 27.0.2
           prometheus-chart-version: 60.3.0
           sealed-secrets-chart-version: 2.7.3
           spark-operator-chart-version: 1.1.25

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -196,7 +196,7 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-chart-version: 27.0.2
+          traefik-chart-version: 31.1.1
           prometheus-chart-version: 60.3.0
           sealed-secrets-chart-version: 2.7.3
           spark-operator-chart-version: 1.1.25
@@ -242,7 +242,7 @@ jobs:
 
       - uses: ./.github/setup-kind
         with:
-          traefik-chart-version: 27.0.2
+          traefik-chart-version: 31.1.1
           prometheus-chart-version: 60.3.0
           sealed-secrets-chart-version: 2.7.3
           spark-operator-chart-version: 1.1.25

--- a/src/mpyl/steps/deploy/k8s/resources/traefik.py
+++ b/src/mpyl/steps/deploy/k8s/resources/traefik.py
@@ -89,7 +89,7 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
         )
 
         super().__init__(
-            api_version="traefik.containo.us/v1alpha1",
+            api_version="traefik.io/v1alpha1",
             kind="IngressRoute",
             metadata=metadata,
             spec={
@@ -104,9 +104,9 @@ class V1AlphaIngressRoute(CustomResourceDefinition):
 class V1AlphaMiddleware(CustomResourceDefinition):
     def __init__(self, metadata: V1ObjectMeta, source_ranges: list[str]):
         super().__init__(
-            api_version="traefik.containo.us/v1alpha1",
+            api_version="traefik.io/v1alpha1",
             kind="Middleware",
             metadata=metadata,
-            spec={"ipWhiteList": {"sourceRange": source_ranges}},
+            spec={"ipAllowList": {"sourceRange": source_ranges}},
             schema="traefik.middleware.schema.yml",
         )

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   annotations:
@@ -14,6 +14,6 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest-ingress-0-whitelist
 spec:
-  ipWhiteList:
+  ipAllowList:
     sourceRange:
     - 10.0.0.1

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   annotations:
@@ -16,7 +16,7 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest-ingress-1-whitelist
 spec:
-  ipWhiteList:
+  ipAllowList:
     sourceRange:
     - 10.0.0.1
     - 1.2.3.0

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-intracloud-https-0.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-intracloud-https-0.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: dockertest
 ---
 # dockertest-ingress-0-http
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -138,7 +138,7 @@ spec:
   - web
 ---
 # dockertest-ingress-0-https
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -170,7 +170,7 @@ spec:
       namespace: traefik
 ---
 # dockertest-ingress-0-whitelist
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   annotations:
@@ -186,12 +186,12 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest-ingress-0-whitelist
 spec:
-  ipWhiteList:
+  ipAllowList:
     sourceRange:
     - 10.0.0.1
 ---
 # dockertest-ingress-1-http
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -220,7 +220,7 @@ spec:
   - web
 ---
 # dockertest-ingress-1-https
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:
@@ -250,7 +250,7 @@ spec:
     secretName: le-other-prod-wildcard-cert
 ---
 # dockertest-ingress-1-whitelist
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   annotations:
@@ -268,7 +268,7 @@ metadata:
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
   name: dockertest-ingress-1-whitelist
 spec:
-  ipWhiteList:
+  ipAllowList:
     sourceRange:
     - 10.0.0.1
     - 1.2.3.0
@@ -276,7 +276,7 @@ spec:
     - 1.2.3.4
 ---
 # dockertest-ingress-intracloud-https-0
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   labels:


### PR DESCRIPTION
This PR upgrades MPyL to use Traefik 3.x.

Changes to notice:
* moved from the `traefik.containo.us/v1alpha1` to the `traefik.io/v1alpha1` API version
* moved from the deprecated `ipWhiteList` middleware setting to `ipAllowList`
